### PR TITLE
feat: 테스트 코드를 위한 테스트용 h2 DB 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
     // security
     implementation 'org.springframework.security:spring-security-crypto:6.3.3'
+
+    // 테스트용 H2 DB
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+    show-sql: true


### PR DESCRIPTION
### 변경 사항
- 테스트코드를 위한 h2 DB 의존성 추가
  - testImplementation을 이용해 build 시 Jar에 포함 안됨
---
### 목적
- CI/CD 시 테스트코드를 이용할 때 직접 DB를 사용할 경우 MySQL 없이 테스트 가능