### PR TITLE
fix: h2와 Mysql 문법 다른점 해결

### DIFF
--- a/src/main/java/kr/kakaotech/community/entity/User.java
+++ b/src/main/java/kr/kakaotech/community/entity/User.java
@@ -12,7 +12,6 @@ import org.hibernate.type.SqlTypes;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-@Builder
 @Getter
 @AllArgsConstructor
 @Entity(name = "users")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,15 +1,12 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE
     driver-class-name: org.h2.Driver
     username: sa
     password:
-
   jpa:
     hibernate:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-        format_sql: true
-    show-sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
### 변경 사항
- h2와 mysql의 문법 다른점으로 인한 오류 해결
  - UUID 생성 방식이 달라 Java에서 직접 생성 후 변수 전달하는 방법으로 변경
---
### 목적
- h2 테스트코드와 mysql 테스트 코드 다른점을 해결하기 위해 사용