### PR TITLE
fix: 정적 이미지 불러오는 권한 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,4 +56,4 @@ cors:
     - access
     - refresh
 
-exclusive-path: /api/auth, /api/error, /api/images, /api/posts/top10, /api/health
+exclusive-path: /api/auth, /api/error, /api/images, /api/posts/top10, /api/health, /api/uploads


### PR DESCRIPTION
### 변경사항
- 정적 이미지 불러오는 url의 권한 변경
---
### 목적
- 정적 이미지의 권한이 변경되어 로그인 하지 않은 사용자도 이미지를 불러올 수 있음