### PR TITLE
fix: 회원탈퇴, 회원수정이 정상동작하지 않는 문제 해결

### DIFF
--- a/src/main/java/kr/kakaotech/community/dto/response/CommentResponse.java
+++ b/src/main/java/kr/kakaotech/community/dto/response/CommentResponse.java
@@ -30,7 +30,7 @@ public class CommentResponse {
                     comment.getId(),
                     comment.getContent(),
                     comment.getUser().getId().toString(),
-                    comment.getUser().getNickname(),
+                    comment.getUser().getNickname().startsWith("탈퇴_") ? "탈퇴한 회원이 작성한 댓글입니다" : comment.getUser().getNickname(),
                     comment.getCreatedAt()
             );
         }

--- a/src/main/java/kr/kakaotech/community/entity/User.java
+++ b/src/main/java/kr/kakaotech/community/entity/User.java
@@ -62,7 +62,7 @@ public class User {
     }
 
     public void deleteUser() {
-        this.nickname = "탈퇴한 회원";
+        this.nickname = "탈퇴_" + this.id.toString().substring(0, 6);
         this.deleted = true;
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/kr/kakaotech/community/service/JWTAuthService.java
+++ b/src/main/java/kr/kakaotech/community/service/JWTAuthService.java
@@ -75,6 +75,7 @@ public class JWTAuthService implements AuthService {
      * 쿠키 maxAge 0으로 설정
      * DB에서 삭제
      */
+    @Transactional
     @Override
     public void deleteAuth(HttpServletRequest request, HttpServletResponse response) {
         addTokenCookie(response, ACCESS_TOKEN, null, 0);


### PR DESCRIPTION
### 변경사항
1. 회원 탈퇴 정책 강화
  - userId를 검증 후 탈퇴
  - 탈퇴 후 cookie 삭제
  - 탈퇴 후 로그인 불가능하도록 비밀번호 삭제
2. 비밀번호 변경
  - 비밀번호 변경 후 강제 로그아웃 및 로그인 창 이동 과정에서 쿠키가 삭제되지않는 현상 수정 
---
### 목적
회원 탈퇴, 비밀번호 변경 과정을 수정하여 회원 관리를 더욱 철처히 진행하도록 개선했습니다.