### PR TITLE
ci: 백엔드 배포 경로 수정

### DIFF
--- a/.github/workflows/ci-cd-ec2.yml
+++ b/.github/workflows/ci-cd-ec2.yml
@@ -73,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    env:
+      BACKEND_APP_DIR: /opt/community/V1/docker/app
     steps:
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v2
@@ -88,5 +90,5 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --targets "Key=tag:Environment,Values=prod" "Key=tag:DeployTarget,Values=community-app" \
             --comment "Deploy Backend" \
-            --parameters "commands=[\"cd /home/ubuntu/app\",\"AWS_REGION=${{ secrets.AWS_REGION }} AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }} BACK_REPOSITORY=${{ secrets.ECR_REPOSITORY }} bash deploy.sh backend latest\"]" \
+            --parameters "commands=[\"cd ${BACKEND_APP_DIR}\",\"AWS_REGION=${{ secrets.AWS_REGION }} AWS_ACCOUNT_ID=${{ secrets.AWS_ACCOUNT_ID }} BACK_REPOSITORY=${{ secrets.ECR_REPOSITORY }} bash deploy.sh backend latest\"]" \
             --output text


### PR DESCRIPTION
## 변경 내용
- 백엔드 GitHub Actions 배포 워크플로의 서버 작업 경로를 실제 운영 경로로 수정했습니다.
- `/home/ubuntu/app` -> `/opt/community/V1/docker/app`

## 배경
- dev 브랜치에는 p95 메트릭 설정이 반영됐지만, 배포 워크플로가 잘못된 경로를 사용해서 실제 운영 컨테이너가 갱신되지 않았습니다.
- 그 결과 운영 백엔드 JAR에는 `http.server.requests` histogram 설정이 반영되지 않았고, Grafana p95/p99 패널이 비어 있었습니다.

## 기대 결과
- dev/main 배포 시 실제 app 서버의 `deploy.sh backend latest`가 정상 실행됩니다.
- 최신 백엔드 이미지가 반영되면 `http_server_requests_seconds_bucket` 메트릭이 노출되고, Grafana p95/p99 패널도 채워집니다.
