### PR TITLE
perf: DB 인덱스 추가, 버그 수정, 트랜잭션 최적화

### DIFF
--- a/src/main/java/kr/kakaotech/community/entity/Post.java
+++ b/src/main/java/kr/kakaotech/community/entity/Post.java
@@ -12,6 +12,10 @@ import java.util.List;
 
 @Getter
 @Entity(name = "posts")
+@Table(name = "posts", indexes = {
+        @Index(name = "idx_posts_deleted_created", columnList = "deleted, created_at DESC"),
+        @Index(name = "idx_posts_deleted_type", columnList = "deleted, type")
+})
 public class Post {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/kakaotech/community/entity/Post.java
+++ b/src/main/java/kr/kakaotech/community/entity/Post.java
@@ -72,13 +72,13 @@ public class Post {
     }
 
     public void updatePost(PostModifyRequest request) {
-        if (!request.getTitle().isBlank() && request.getTitle() != null) {
+        if (request.getTitle() != null && !request.getTitle().isBlank()) {
             this.title = request.getTitle();
         }
-        if (!request.getContent().isBlank() && request.getContent() != null) {
+        if (request.getContent() != null && !request.getContent().isBlank()) {
             this.content = request.getContent();
         }
-        if (!request.getType().isBlank() && request.getType() != null) {
+        if (request.getType() != null && !request.getType().isBlank()) {
             this.type = PostType.valueOf(request.getType().toUpperCase());
         }
     }

--- a/src/main/java/kr/kakaotech/community/entity/PostLike.java
+++ b/src/main/java/kr/kakaotech/community/entity/PostLike.java
@@ -9,6 +9,9 @@ import java.time.LocalDateTime;
 @Entity(name = "post_likes")
 @Getter
 @NoArgsConstructor
+@Table(name = "post_likes",
+        uniqueConstraints = @UniqueConstraint(name = "uk_post_likes_user_post", columnNames = {"user_id", "post_id"})
+)
 public class PostLike {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/kakaotech/community/repository/PostStatusRepository.java
+++ b/src/main/java/kr/kakaotech/community/repository/PostStatusRepository.java
@@ -42,4 +42,12 @@ public interface PostStatusRepository extends JpaRepository<PostStatus, Integer>
     """, nativeQuery = true)
     void incrementCommentCount(@Param("id") int id);
 
+    @Modifying
+    @Query(value = """
+        UPDATE post_statuses
+        SET comment_count = GREATEST(comment_count - 1, 0)
+        WHERE post_id = :id
+    """, nativeQuery = true)
+    void decrementCommentCount(@Param("id") int id);
+
 }

--- a/src/main/java/kr/kakaotech/community/service/CommentService.java
+++ b/src/main/java/kr/kakaotech/community/service/CommentService.java
@@ -76,6 +76,7 @@ public class CommentService {
         Comment comment = validateComment(userId, commentId);
 
         comment.delete();
+        postStatusRepository.decrementCommentCount(comment.getPost().getId());
     }
 
     /**

--- a/src/main/java/kr/kakaotech/community/service/LikeService.java
+++ b/src/main/java/kr/kakaotech/community/service/LikeService.java
@@ -65,6 +65,7 @@ public class LikeService {
     /**
      * 좋아요 상태 가져오기
      */
+    @Transactional(readOnly = true)
     public boolean getLikeStatus(Optional<Object> optionalUserId, int postId) {
         if (optionalUserId.isEmpty()) return false;
 
@@ -75,8 +76,8 @@ public class LikeService {
     /**
      * 좋아요 갯수 세기
      */
+    @Transactional(readOnly = true)
     public int getLikeCount(int postId) {
-        int i = likeRepository.countByPost_Id(postId);
         return postStatusRepository.findById(postId).get().getLikeCount();
     }
 }

--- a/src/main/java/kr/kakaotech/community/service/PostService.java
+++ b/src/main/java/kr/kakaotech/community/service/PostService.java
@@ -96,7 +96,7 @@ public class PostService {
     /**
      * 인덱스용 이미지 포함 게시글 목록 조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PostSummaryWithImageResponse> getPostListWithImage(int size) {
         Pageable pageable = PageRequest.of(0, size);
         return postRepository.findPostWithImage(pageable);
@@ -105,7 +105,7 @@ public class PostService {
     /**
      * 게시글 목록 조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public PostListResponse getPostList(Integer cursor, int size) {
         Pageable pageable = PageRequest.of(0, size);
         List<PostSummaryResponse> postList;
@@ -122,6 +122,7 @@ public class PostService {
     /**
      * 기간에 따른 인기글 목록 메서드
      */
+    @Transactional(readOnly = true)
     public PostListResponse getLikePostList(Integer cursor, String period, int size) {
         LocalDateTime startDate = switch (period) {
             case "daily" -> LocalDateTime.now().minusDays(1);
@@ -140,6 +141,7 @@ public class PostService {
     /**
      * nickname에 따른 검색
      */
+    @Transactional(readOnly = true)
     public PostListResponse getNicknamePostList(Integer cursor, String nickname, int size) {
         List<PostSummaryResponse> postList = postRepository.findPostByNickname(
                 nickname,
@@ -152,6 +154,7 @@ public class PostService {
     /**
      * TOP 10 좋아요 순서 정렬
      */
+    @Transactional(readOnly = true)
     public PostListResponse getPostTop10List() {
         List<PostSummaryResponse> postList = postRepository.findTop10Post(PageRequest.of(0, 10));
 
@@ -161,7 +164,7 @@ public class PostService {
     /**
      * 게시글 상세조회
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public PostDetailResponse getPostDetails(int postId) {
         Post post = postRepository.findPostDetailsWithImages(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));

--- a/src/main/java/kr/kakaotech/community/service/PostStatusService.java
+++ b/src/main/java/kr/kakaotech/community/service/PostStatusService.java
@@ -25,6 +25,7 @@ public class PostStatusService {
         postStatusRepository.incrementViewCount(postId);
     }
 
+    @Transactional(readOnly = true)
     public PostTypeCountResponse getPostTypeCount(String type) {
         return new PostTypeCountResponse(postRepository.countByDeletedFalseAndType(PostType.valueOf(type.toUpperCase())));
     }
@@ -34,6 +35,7 @@ public class PostStatusService {
      *
      * 다른 통계정보는 각자 들고오기 때문에 임시 삭제
      */
+    @Transactional(readOnly = true)
     public PostStatusResponse getPostStatus(int postId) {
         return new PostStatusResponse(postStatusRepository.findById(postId).map(PostStatus::getViewCount).orElse(0));
     }

--- a/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
@@ -73,7 +73,6 @@ class LikeServiceTest {
             given(postRepository.getReferenceById(postId)).willReturn(postRef);
             given(likeRepository.save(any(PostLike.class))).willReturn(null);
             // getLikeCount 내부 호출
-            given(likeRepository.countByPost_Id(postId)).willReturn(1);
             ReflectionTestUtils.setField(postStatus, "likeCount", 1);
             given(postStatusRepository.findById(postId)).willReturn(Optional.of(postStatus));
 
@@ -97,7 +96,6 @@ class LikeServiceTest {
 
             given(likeRepository.findByUser_IdAndPost_Id(userId, postId)).willReturn(Optional.of(existingLike));
             // getLikeCount 내부 호출
-            given(likeRepository.countByPost_Id(postId)).willReturn(0);
             ReflectionTestUtils.setField(postStatus, "likeCount", 0);
             given(postStatusRepository.findById(postId)).willReturn(Optional.of(postStatus));
 
@@ -192,7 +190,6 @@ class LikeServiceTest {
         void success() {
             // given
             ReflectionTestUtils.setField(postStatus, "likeCount", 42);
-            given(likeRepository.countByPost_Id(postId)).willReturn(42);
             given(postStatusRepository.findById(postId)).willReturn(Optional.of(postStatus));
 
             // when


### PR DESCRIPTION
## 요약

  k6 부하 테스트(50 VUs, 5분)에서 발견된 성능 문제를 해결합니다.

  **개선 전 측정 결과:**
  - Top10 API p95: 35s (100만 row 풀 테이블 스캔 → 커넥션 풀 고갈)
  - 전체 에러율: 45.4%
  - RPS: 2.36/s
  - HikariCP Pending: 40+, Pool Utilization: 100%

  ## 변경 사항

  ### 1. 복합 인덱스 및 유니크 제약 추가
  - `posts` 테이블: `(deleted, created_at)`, `(deleted, type)` 복합 인덱스 추가
  - `post_likes` 테이블: `(user_id, post_id)` 유니크 제약 추가로 중복 좋아요 방지

  ### 2. 버그 수정 및 데이터 정합성 개선
  - `Post.updatePost()` NPE 버그 수정: null 체크 순서 교정
  - `LikeService.getLikeCount()` 사용하지 않는 COUNT 쿼리 제거 (500만 row 불필요 스캔)
  - 댓글 삭제 시 `post_statuses.comment_count` 감소 로직 추가
  - `LikeServiceTest` 불필요한 mock stubbing 제거

  ### 3. 읽기 전용 트랜잭션 최적화
  - `PostService` 6개, `LikeService` 2개, `PostStatusService` 2개 읽기 메서드에 `@Transactional(readOnly = true)` 적용

  ## 수정 파일
  - `Post.java` - 복합 인덱스, NPE 수정
  - `PostLike.java` - 유니크 제약
  - `PostService.java` - readOnly 적용
  - `LikeService.java` - 죽은 쿼리 제거, readOnly 적용
  - `PostStatusService.java` - readOnly 적용
  - `PostStatusRepository.java` - decrementCommentCount 추가
  - `CommentService.java` - 댓글 삭제 시 카운트 감소
  - `LikeServiceTest.java` - mock stubbing 수정

  ## 테스트 계획
  - [x] 기존 단위 테스트 통과 확인
  - [ ] 배포 후 동일 조건(50 VUs, 5분) k6 재측정
  - [ ] Grafana before/after 스크린샷 비교
  - [ ] EXPLAIN ANALYZE로 인덱스 적용 확인
