### PR TITLE
✨ feat: Top10 인기글 Redis cache-aside 패턴 적용

### DIFF
--- a/src/main/java/kr/kakaotech/community/dto/response/PostSummaryResponse.java
+++ b/src/main/java/kr/kakaotech/community/dto/response/PostSummaryResponse.java
@@ -5,11 +5,13 @@ import kr.kakaotech.community.entity.PostStatus;
 import kr.kakaotech.community.entity.PostType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class PostSummaryResponse {
     private int id;

--- a/src/main/java/kr/kakaotech/community/service/LikeService.java
+++ b/src/main/java/kr/kakaotech/community/service/LikeService.java
@@ -28,6 +28,7 @@ public class LikeService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final PostStatusRepository postStatusRepository;
+    private final PostService postService;
 
     @Transactional
     public LikeResponse toggleLike(UUID userId, int postId) {
@@ -37,6 +38,7 @@ public class LikeService {
         if (optionalPostLike.isPresent()) {
             likeRepository.delete(optionalPostLike.get());
             postStatusRepository.decrementLikeCount(postId);
+            postService.evictTop10Cache();
 
             return new LikeResponse(false, getLikeCount(postId));
         }
@@ -52,6 +54,7 @@ public class LikeService {
             likeRepository.save(newLike);
 
             postStatusRepository.incrementLikeCount(postId);
+            postService.evictTop10Cache();
 
             return new LikeResponse(true, getLikeCount(postId));
 

--- a/src/main/java/kr/kakaotech/community/service/PostService.java
+++ b/src/main/java/kr/kakaotech/community/service/PostService.java
@@ -13,10 +13,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -30,9 +32,13 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostStatusRepository postStatusRepository;
     private final ImageService imageService;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     private final int IMAGE_LIMIT_COUNT = 5;
     private final PostStatusService postStatusService;
+
+    private static final String TOP10_CACHE_KEY = "posts:top10";
+    private static final Duration TOP10_CACHE_TTL = Duration.ofMinutes(5);
 
     /**
      * Post 등록
@@ -152,13 +158,27 @@ public class PostService {
     }
 
     /**
-     * TOP 10 좋아요 순서 정렬
+     * TOP 10 좋아요 순서 정렬 (Redis cache-aside)
      */
     @Transactional(readOnly = true)
+    @SuppressWarnings("unchecked")
     public PostListResponse getPostTop10List() {
-        List<PostSummaryResponse> postList = postRepository.findTop10Post(PageRequest.of(0, 10));
+        List<PostSummaryResponse> postList = (List<PostSummaryResponse>) redisTemplate.opsForValue().get(TOP10_CACHE_KEY);
+
+        if (postList == null) {
+            log.info("Top10 cache miss - querying DB");
+            postList = postRepository.findTop10Post(PageRequest.of(0, 10));
+            redisTemplate.opsForValue().set(TOP10_CACHE_KEY, postList, TOP10_CACHE_TTL);
+        }
 
         return getPostListAndNextCursorResponse(11, postList);
+    }
+
+    /**
+     * Top10 캐시 무효화
+     */
+    public void evictTop10Cache() {
+        redisTemplate.delete(TOP10_CACHE_KEY);
     }
 
     /**

--- a/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
@@ -39,6 +39,8 @@ class LikeServiceTest {
     PostRepository postRepository;
     @Mock
     PostStatusRepository postStatusRepository;
+    @Mock
+    PostService postService;
 
     @InjectMocks
     LikeService likeService;

--- a/src/test/java/kr/kakaotech/community/service/PostServiceTest.java
+++ b/src/test/java/kr/kakaotech/community/service/PostServiceTest.java
@@ -44,6 +44,10 @@ class PostServiceTest {
     ImageService imageService;
     @Mock
     PostStatusService postStatusService;
+    @Mock
+    org.springframework.data.redis.core.RedisTemplate<String, Object> redisTemplate;
+    @Mock
+    org.springframework.data.redis.core.ValueOperations<String, Object> valueOperations;
 
     @InjectMocks
     PostService postService;
@@ -373,6 +377,8 @@ class PostServiceTest {
             List<PostSummaryResponse> posts = List.of(
                     createSummary(1), createSummary(2), createSummary(3)
             );
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get("posts:top10")).willReturn(null);
             given(postRepository.findTop10Post(any())).willReturn(posts);
 
             // when


### PR DESCRIPTION
   ## 요약

   k6 부하 테스트(50 VUs, 5분)에서 발견된 성능 문제를 해결합니다.

   ### 개선 전 측정 결과 (baseline)
   - Top10 API p95: **35s** (100만 row 풀 테이블 스캔 → HikariCP 커넥션 풀 고갈)
   - 전체 에러율: **45.4%**
   - RPS: **2.36/s**
   - HikariCP Pending: 40+, Pool Utilization: 100%

   ## 변경 사항

   ### 1. 복합 인덱스 및 유니크 제약 추가
   - `posts` 테이블: `(deleted, created_at)`, `(deleted, type)` 복합 인덱스
   - `post_likes` 테이블: `(user_id, post_id)` 유니크 제약으로 중복 좋아요 방지

   ### 2. 버그 수정 및 데이터 정합성 개선
   - `Post.updatePost()` NPE 버그 수정: null 체크 순서 교정
   - `LikeService.getLikeCount()` 사용하지 않는 COUNT 쿼리 제거 (500만 row 불필요 스캔)
   - 댓글 삭제 시 `post_statuses.comment_count` 감소 로직 추가

   ### 3. 읽기 전용 트랜잭션 최적화
   - `PostService` 6개, `LikeService` 2개, `PostStatusService` 2개 읽기 메서드에 `@Transactional(readOnly = true)` 적용

   ### 4. Top10 인기글 Redis 캐싱 (cache-aside 패턴)
   - `getPostTop10List()`에 Redis 캐싱 추가 (TTL 5분)
   - 좋아요 토글 시 Top10 캐시 무효화
   - 인덱스만으로 해결 불가한 cross-table JOIN+정렬 문제를 캐싱으로 근본 해결

   ## 테스트 계획
   - [x] 기존 단위 테스트 통과 확인 (75건 전체 통과)
   - [ ] 배포 후 동일 조건(50 VUs, 5분) k6 재측정
   - [ ] Grafana before/after 스크린샷 비교
   - [ ] Redis 캐시 히트율 확인