### PR TITLE
Top10 인기글 Redis cache-aside 패턴 적용

### DIFF
--- a/src/main/java/kr/kakaotech/community/global/config/RedisConfig.java
+++ b/src/main/java/kr/kakaotech/community/global/config/RedisConfig.java
@@ -36,7 +36,8 @@ public class RedisConfig {
         template.setValueSerializer(serializer);
         template.setHashValueSerializer(serializer);
 
-        template.setEnableTransactionSupport(true); // 트랜잭션 필요 시
+        // enableTransactionSupport를 끄면 @Transactional 내에서도 Redis 읽기가 즉시 반환됨
+        // 켜면 MULTI/EXEC로 큐잉되어 get()이 null을 반환하는 문제 발생
         template.afterPropertiesSet();
 
         return template;

--- a/src/main/java/kr/kakaotech/community/service/LikeService.java
+++ b/src/main/java/kr/kakaotech/community/service/LikeService.java
@@ -28,7 +28,6 @@ public class LikeService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final PostStatusRepository postStatusRepository;
-    private final PostService postService;
 
     @Transactional
     public LikeResponse toggleLike(UUID userId, int postId) {
@@ -38,7 +37,6 @@ public class LikeService {
         if (optionalPostLike.isPresent()) {
             likeRepository.delete(optionalPostLike.get());
             postStatusRepository.decrementLikeCount(postId);
-            postService.evictTop10Cache();
 
             return new LikeResponse(false, getLikeCount(postId));
         }
@@ -54,7 +52,6 @@ public class LikeService {
             likeRepository.save(newLike);
 
             postStatusRepository.incrementLikeCount(postId);
-            postService.evictTop10Cache();
 
             return new LikeResponse(true, getLikeCount(postId));
 

--- a/src/main/java/kr/kakaotech/community/service/PostService.java
+++ b/src/main/java/kr/kakaotech/community/service/PostService.java
@@ -175,13 +175,6 @@ public class PostService {
     }
 
     /**
-     * Top10 캐시 무효화
-     */
-    public void evictTop10Cache() {
-        redisTemplate.delete(TOP10_CACHE_KEY);
-    }
-
-    /**
      * 게시글 상세조회
      */
     @Transactional(readOnly = true)

--- a/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
@@ -39,8 +39,6 @@ class LikeServiceTest {
     PostRepository postRepository;
     @Mock
     PostStatusRepository postStatusRepository;
-    @Mock
-    PostService postService;
 
     @InjectMocks
     LikeService likeService;


### PR DESCRIPTION
## 요약
- Top10 인기글 조회에 Redis cache-aside 패턴 적용 (TTL 5분)
- `RedisConfig`의 `enableTransactionSupport(true)` 제거 — `@Transactional` 내에서 Redis `get()`이 null 반환하는 버그 수정
- 캐시 무효화를 좋아요 토글 시 즉시 삭제 → TTL 기반 만료로 변경

## 변경 사항
- `PostService.getPostTop10List()`: DB 직접 조회 → Redis 캐시 우선 조회, miss 시 DB 조회 후 캐시 저장
- `RedisConfig`: `enableTransactionSupport(true)` 제거
- `PostSummaryResponse`: Redis JSON 역직렬화를 위한 `@NoArgsConstructor` 추가
- `LikeService`: 불필요한 `PostService` 의존성 제거
- 테스트 코드 업데이트

## 배경
- k6 부하 테스트(50 VUs, 5분)에서 Top10 API가 평균 34초, p95 1분으로 타임아웃 발생
- 복합 인덱스로도 개선 불가 — ORDER BY가 JOIN된 다른 테이블(`post_statuses.like_count`) 기준
- `enableTransactionSupport(true)`가 MULTI/EXEC 큐잉을 유발해 캐시가 동작하지 않는 문제 수정
- 좋아요 토글마다 캐시 삭제 시 빈번한 DB 조회 발생 → TTL(5분) 만료에만 의존하도록 변경

## 테스트 계획
- [ ] 배포 후 k6 부하 테스트 재실행하여 Top10 p95 latency 개선 확인
- [ ] Redis 캐시 히트 로그 확인 (`Top10 cache miss` 로그가 5분 주기로만 출력되는지)