### PR TITLE
✨ feat: datasource-proxy 기반 요청별 SQL 쿼리 카운팅 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     // aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+    // datasource-proxy (SQL query counting)
+    implementation 'net.ttddyy:datasource-proxy:1.10'
+
     // logback json (for PLG stack / Alloy)
     implementation 'ch.qos.logback.contrib:logback-json-classic:0.1.5'
     implementation 'ch.qos.logback.contrib:logback-jackson:0.1.5'

--- a/src/main/java/kr/kakaotech/community/global/aop/ApiLoggingAspect.java
+++ b/src/main/java/kr/kakaotech/community/global/aop/ApiLoggingAspect.java
@@ -1,6 +1,9 @@
 package kr.kakaotech.community.global.aop;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kr.kakaotech.community.global.monitoring.QueryCountHolder;
+import kr.kakaotech.community.global.monitoring.QueryCountMetrics;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -12,7 +15,12 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Aspect
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class ApiLoggingAspect {
+
+    private static final int QUERY_COUNT_WARN_THRESHOLD = 10;
+
+    private final QueryCountMetrics queryCountMetrics;
 
     @Around("execution(* kr.kakaotech.community.controller..*(..))")
     public Object logApiCall(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -33,11 +41,18 @@ public class ApiLoggingAspect {
         try {
             Object result = joinPoint.proceed();
             long elapsed = System.currentTimeMillis() - start;
-            log.info("[API Response] {} {} → {}ms", method, uri, elapsed);
+            int queryCount = QueryCountHolder.getCount();
+            queryCountMetrics.record(queryCount);
+            log.info("[API Response] {} {} → {}ms | queries={}", method, uri, elapsed, queryCount);
+            if (queryCount >= QUERY_COUNT_WARN_THRESHOLD) {
+                log.warn("[N+1 WARNING] {} {} executed {} queries (threshold={})", method, uri, queryCount, QUERY_COUNT_WARN_THRESHOLD);
+            }
             return result;
         } catch (Exception e) {
             long elapsed = System.currentTimeMillis() - start;
-            log.error("[API Error] {} {} → {}ms | {}", method, uri, elapsed, e.getMessage());
+            int queryCount = QueryCountHolder.getCount();
+            queryCountMetrics.record(queryCount);
+            log.error("[API Error] {} {} → {}ms | queries={} | {}", method, uri, elapsed, queryCount, e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/kr/kakaotech/community/global/config/DataSourceProxyConfig.java
+++ b/src/main/java/kr/kakaotech/community/global/config/DataSourceProxyConfig.java
@@ -1,0 +1,24 @@
+package kr.kakaotech.community.global.config;
+
+import kr.kakaotech.community.global.monitoring.QueryCountListener;
+import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DataSourceProxyConfig implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof DataSource dataSource && !(bean instanceof net.ttddyy.dsproxy.support.ProxyDataSource)) {
+            return ProxyDataSourceBuilder.create(dataSource)
+                    .name("queryCountProxy")
+                    .listener(new QueryCountListener())
+                    .build();
+        }
+        return bean;
+    }
+}

--- a/src/main/java/kr/kakaotech/community/global/filter/MDCFilter.java
+++ b/src/main/java/kr/kakaotech/community/global/filter/MDCFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import kr.kakaotech.community.global.monitoring.QueryCountHolder;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -21,12 +22,15 @@ public class MDCFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         try {
+            QueryCountHolder.reset();
             MDC.put("requestId", UUID.randomUUID().toString().substring(0, 8));
             MDC.put("method", request.getMethod());
             MDC.put("uri", request.getRequestURI());
             MDC.put("clientIp", request.getRemoteAddr());
             filterChain.doFilter(request, response);
         } finally {
+            MDC.put("queryCount", String.valueOf(QueryCountHolder.getCount()));
+            QueryCountHolder.reset();
             MDC.clear();
         }
     }

--- a/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountHolder.java
+++ b/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountHolder.java
@@ -1,0 +1,18 @@
+package kr.kakaotech.community.global.monitoring;
+
+public class QueryCountHolder {
+
+    private static final ThreadLocal<Integer> count = ThreadLocal.withInitial(() -> 0);
+
+    public static void increment() {
+        count.set(count.get() + 1);
+    }
+
+    public static int getCount() {
+        return count.get();
+    }
+
+    public static void reset() {
+        count.remove();
+    }
+}

--- a/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountListener.java
+++ b/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountListener.java
@@ -1,0 +1,19 @@
+package kr.kakaotech.community.global.monitoring;
+
+import net.ttddyy.dsproxy.ExecutionInfo;
+import net.ttddyy.dsproxy.QueryInfo;
+import net.ttddyy.dsproxy.listener.QueryExecutionListener;
+
+import java.util.List;
+
+public class QueryCountListener implements QueryExecutionListener {
+
+    @Override
+    public void beforeQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+    }
+
+    @Override
+    public void afterQuery(ExecutionInfo execInfo, List<QueryInfo> queryInfoList) {
+        QueryCountHolder.increment();
+    }
+}

--- a/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountMetrics.java
+++ b/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountMetrics.java
@@ -1,0 +1,22 @@
+package kr.kakaotech.community.global.monitoring;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryCountMetrics {
+
+    private final DistributionSummary summary;
+
+    public QueryCountMetrics(MeterRegistry meterRegistry) {
+        this.summary = DistributionSummary.builder("jpa.query.count")
+                .description("Number of SQL queries per API request")
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry);
+    }
+
+    public void record(int queryCount) {
+        summary.record(queryCount);
+    }
+}


### PR DESCRIPTION
## 요약
- datasource-proxy를 활용하여 API 요청당 실행되는 SQL 쿼리 수를 추적하는 기능 구현
- N+1 문제 감지를 위해 쿼리 10개 이상 시 WARN 로그 출력
- Micrometer DistributionSummary로 Prometheus 메트릭(`jpa.query.count`) 노출 (p50/p95/p99)

## 변경 사항
### 새 파일
- `QueryCountHolder` — ThreadLocal 기반 요청별 쿼리 카운터
- `QueryCountListener` — datasource-proxy 리스너, 쿼리 실행 시 카운터 증가
- `DataSourceProxyConfig` — BeanPostProcessor로 DataSource를 ProxyDataSource로 래핑
- `QueryCountMetrics` — Micrometer DistributionSummary로 Prometheus 메트릭 노출

### 수정 파일
- `build.gradle` — `datasource-proxy:1.10` 의존성 추가
- `MDCFilter` — 요청 시작/종료 시 QueryCountHolder 초기화 및 정리
- `ApiLoggingAspect` — 응답 로그에 `queries=N` 추가, 10개 이상 시 `[N+1 WARNING]` 출력

## 로그 출력 예시
```
[API Response] GET /api/posts → 45ms | queries=3
[N+1 WARNING] GET /api/posts/1 executed 15 queries (threshold=10)
```

## 테스트 계획
- [ ] 로컬에서 API 호출 후 로그에 `queries=N` 출력 확인
- [ ] `/actuator/prometheus`에서 `jpa_query_count` 메트릭 확인
- [ ] Lazy loading 엔드포인트 호출하여 N+1 WARNING 로그 발생 확인