### PR TITLE
datasource-proxy 기반 요청별 SQL 쿼리 카운팅 및 엔드포인트별 메트릭 구현

### DIFF
--- a/src/main/java/kr/kakaotech/community/global/aop/ApiLoggingAspect.java
+++ b/src/main/java/kr/kakaotech/community/global/aop/ApiLoggingAspect.java
@@ -11,6 +11,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
 
 @Aspect
 @Component
@@ -28,10 +29,13 @@ public class ApiLoggingAspect {
 
         String method = "UNKNOWN";
         String uri = "UNKNOWN";
+        String uriPattern = "UNKNOWN";
         if (attributes != null) {
             HttpServletRequest request = attributes.getRequest();
             method = request.getMethod();
             uri = request.getRequestURI();
+            String pattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+            uriPattern = (pattern != null) ? pattern : uri;
         }
 
         String handler = joinPoint.getSignature().toShortString();
@@ -42,7 +46,7 @@ public class ApiLoggingAspect {
             Object result = joinPoint.proceed();
             long elapsed = System.currentTimeMillis() - start;
             int queryCount = QueryCountHolder.getCount();
-            queryCountMetrics.record(queryCount);
+            queryCountMetrics.record(queryCount, method, uriPattern);
             log.info("[API Response] {} {} → {}ms | queries={}", method, uri, elapsed, queryCount);
             if (queryCount >= QUERY_COUNT_WARN_THRESHOLD) {
                 log.warn("[N+1 WARNING] {} {} executed {} queries (threshold={})", method, uri, queryCount, QUERY_COUNT_WARN_THRESHOLD);
@@ -51,7 +55,7 @@ public class ApiLoggingAspect {
         } catch (Exception e) {
             long elapsed = System.currentTimeMillis() - start;
             int queryCount = QueryCountHolder.getCount();
-            queryCountMetrics.record(queryCount);
+            queryCountMetrics.record(queryCount, method, uriPattern);
             log.error("[API Error] {} {} → {}ms | queries={} | {}", method, uri, elapsed, queryCount, e.getMessage());
             throw e;
         }

--- a/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountMetrics.java
+++ b/src/main/java/kr/kakaotech/community/global/monitoring/QueryCountMetrics.java
@@ -7,16 +7,25 @@ import org.springframework.stereotype.Component;
 @Component
 public class QueryCountMetrics {
 
-    private final DistributionSummary summary;
+    private final MeterRegistry meterRegistry;
+    private final DistributionSummary globalSummary;
 
     public QueryCountMetrics(MeterRegistry meterRegistry) {
-        this.summary = DistributionSummary.builder("jpa.query.count")
+        this.meterRegistry = meterRegistry;
+        this.globalSummary = DistributionSummary.builder("jpa.query.count")
                 .description("Number of SQL queries per API request")
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(meterRegistry);
     }
 
-    public void record(int queryCount) {
-        summary.record(queryCount);
+    public void record(int queryCount, String method, String uri) {
+        globalSummary.record(queryCount);
+        DistributionSummary.builder("jpa.query.count.by.endpoint")
+                .description("Number of SQL queries per API endpoint")
+                .tag("method", method)
+                .tag("uri", uri)
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry)
+                .record(queryCount);
     }
 }


### PR DESCRIPTION
## 요약
- datasource-proxy를 활용하여 API 요청당 실행되는 SQL 쿼리 수를 추적하는 기능 구현
- N+1 문제 감지를 위해 쿼리 10개 이상 시 WARN 로그 출력
- Micrometer DistributionSummary로 Prometheus 메트릭 노출 (`jpa.query.count`, `jpa.query.count.by.endpoint`)
- 엔드포인트별 method/uri 태그로 개별 API의 쿼리 수 모니터링 가능

## 변경 사항

### 새 파일
- `QueryCountHolder` — ThreadLocal 기반 요청별 쿼리 카운터
- `QueryCountListener` — datasource-proxy 리스너, 쿼리 실행 시 카운터 증가
- `DataSourceProxyConfig` — BeanPostProcessor로 DataSource를 ProxyDataSource로 래핑
- `QueryCountMetrics` — 전역 + 엔드포인트별 Prometheus 메트릭 노출 (p50/p95/p99)

### 수정 파일
- `build.gradle` — `datasource-proxy:1.10` 의존성 추가
- `MDCFilter` — 요청 시작/종료 시 QueryCountHolder 초기화 및 정리
- `ApiLoggingAspect` — 응답 로그에 `queries=N` 추가, 10개 이상 시 `[N+1 WARNING]` 출력, URI 템플릿 패턴으로 메트릭 태그 기록

## 로그 출력 예시
```
[API Response] GET /api/posts → 45ms | queries=3
[N+1 WARNING] GET /api/posts/1 executed 15 queries (threshold=10)
```

## 테스트 계획
- [ ] 로컬에서 API 호출 후 로그에 `queries=N` 출력 확인
- [ ] `/actuator/prometheus`에서 `jpa_query_count`, `jpa_query_count_by_endpoint` 메트릭 확인
- [ ] Lazy loading 엔드포인트 호출하여 N+1 WARNING 로그 발생 확인
- [ ] 엔드포인트별 메트릭에 method/uri 태그가 정상적으로 붙는지 확인