### PR TITLE
Top10 쿼리 기간 제한 추가 (최근 2개월)

### DIFF
--- a/src/main/java/kr/kakaotech/community/repository/PostRepository.java
+++ b/src/main/java/kr/kakaotech/community/repository/PostRepository.java
@@ -68,9 +68,10 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
                 left join u.image ui
                 where p.deleted = false
                 AND p.type = 'completed'
+                AND p.createdAt >= :startDate
                 order by ps.likeCount desc
             """)
-    List<PostSummaryResponse> findTop10Post(Pageable pageable);
+    List<PostSummaryResponse> findTop10Post(@Param("startDate") LocalDateTime startDate, Pageable pageable);
 
     @Query("""
                 SELECT new kr.kakaotech.community.dto.response.PostSummaryResponse(

--- a/src/main/java/kr/kakaotech/community/service/PostService.java
+++ b/src/main/java/kr/kakaotech/community/service/PostService.java
@@ -167,7 +167,8 @@ public class PostService {
 
         if (postList == null) {
             log.info("Top10 cache miss - querying DB");
-            postList = postRepository.findTop10Post(PageRequest.of(0, 10));
+            LocalDateTime startDate = LocalDateTime.now().minusMonths(2);
+            postList = postRepository.findTop10Post(startDate, PageRequest.of(0, 10));
             redisTemplate.opsForValue().set(TOP10_CACHE_KEY, postList, TOP10_CACHE_TTL);
         }
 

--- a/src/test/java/kr/kakaotech/community/service/PostServiceTest.java
+++ b/src/test/java/kr/kakaotech/community/service/PostServiceTest.java
@@ -379,7 +379,7 @@ class PostServiceTest {
             );
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
             given(valueOperations.get("posts:top10")).willReturn(null);
-            given(postRepository.findTop10Post(any())).willReturn(posts);
+            given(postRepository.findTop10Post(any(LocalDateTime.class), any())).willReturn(posts);
 
             // when
             PostListResponse response = postService.getPostTop10List();


### PR DESCRIPTION
## 요약
- Top10 인기글 쿼리에 `createdAt >= 2개월 전` 조건 추가
- 전체 데이터 대상 JOIN + 정렬 → 최근 2개월로 범위 축소

## 배경
- Top10 쿼리가 수십만 건을 JOIN + `like_count DESC` 정렬하여 cache miss 시 수 초~수십 초 소요
- 기간 제한으로 정렬 대상 데이터를 줄여 쿼리 자체의 실행 시간을 단축

## 변경 파일
- `PostRepository.java`: `findTop10Post`에 `startDate` 파라미터 추가
- `PostService.java`: `LocalDateTime.now().minusMonths(2)` 전달
- `PostServiceTest.java`: mock 시그니처 수정