### PR TITLE
Top10 쿼리 기간 제한 및 Redis 장애 fallback 추가

### DIFF
--- a/src/main/java/kr/kakaotech/community/service/PostService.java
+++ b/src/main/java/kr/kakaotech/community/service/PostService.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -163,13 +165,24 @@ public class PostService {
     @Transactional(readOnly = true)
     @SuppressWarnings("unchecked")
     public PostListResponse getPostTop10List() {
-        List<PostSummaryResponse> postList = (List<PostSummaryResponse>) redisTemplate.opsForValue().get(TOP10_CACHE_KEY);
+        List<PostSummaryResponse> postList = null;
+
+        try {
+            postList = (List<PostSummaryResponse>) redisTemplate.opsForValue().get(TOP10_CACHE_KEY);
+        } catch (RedisConnectionFailureException | RedisSystemException e) {
+            log.warn("Redis 조회 실패 - DB fallback. reason={}", e.getMessage());
+        }
 
         if (postList == null) {
             log.info("Top10 cache miss - querying DB");
             LocalDateTime startDate = LocalDateTime.now().minusMonths(2);
             postList = postRepository.findTop10Post(startDate, PageRequest.of(0, 10));
-            redisTemplate.opsForValue().set(TOP10_CACHE_KEY, postList, TOP10_CACHE_TTL);
+
+            try {
+                redisTemplate.opsForValue().set(TOP10_CACHE_KEY, postList, TOP10_CACHE_TTL);
+            } catch (RedisConnectionFailureException | RedisSystemException e) {
+                log.warn("Redis 저장 실패 - 다음 요청에서 재시도. reason={}", e.getMessage());
+            }
         }
 
         return getPostListAndNextCursorResponse(11, postList);


### PR DESCRIPTION
## 요약
- Top10 쿼리에 최근 2개월 기간 제한 추가하여 쿼리 실행 시간 단축
- Redis 장애 시 DB fallback 처리 추가

## 변경 사항

### 쿼리 최적화
- `findTop10Post`에 `createdAt >= 2개월 전` 조건 추가
- 전체 데이터 대상 JOIN + 정렬 → 최근 2개월로 범위 축소
- 단건 쿼리 기준 5,695ms → 2,054ms (64% 감소)

### Redis 장애 fallback
- `RedisConnectionFailureException`, `RedisSystemException` catch하여 DB fallback
- Redis 조회 실패 시 DB에서 직접 조회, Redis 저장 실패 시 다음 요청에서 재시도

### 기타
- 테스트 H2 설정 수정
- Top10 쿼리 실행 시간 측정 통합 테스트 추가

## 테스트 계획
- [ ] k6 부하 테스트로 cache miss 시 latency 감소 확인
- [ ] Redis 컨테이너 중지 후 API 정상 응답 확인