### PR TITLE
⚡️ Top10 캐싱 성능 개선 및 Redis 장애 대응

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -25,6 +25,7 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST:localhost}
       port: ${SPRING_DATA_REDIS_PORT:6379}
       password: ${SPRING_DATA_REDIS_PASSWORD:}
+      timeout: 3s
 
   thymeleaf:
     cache: true


### PR DESCRIPTION
## Summary
- Top10 쿼리에 기간 제한(최근 2개월) 추가하여 cache miss 시 DB 쿼리 성능 개선
- Redis 장애 시 DB fallback 처리 추가
- Redis 연결 타임아웃 3초 설정으로 장애 시 빠른 fallback 보장

## 성능 개선 결과 (k6 부하 테스트, 50 VUs / 5분)

| 지표 | 이전 | 이후 | 변화 |
|---|---|---|---|
| Top10 avg | 315ms | 120ms | 62% 감소 |
| Top10 max | 58.01s | 12.81s | 78% 감소 |
| 타임아웃 | 40건 (0.22%) | 0건 | 완전 해소 |

## 주요 변경사항
- Top10 쿼리에 `WHERE created_at >= 2개월 전` 조건 추가
- `RedisConnectionFailureException` catch → DB fallback 로직
- `spring.data.redis.timeout: 3s` 설정 추가

## Test plan
- [x] k6 부하 테스트로 성능 개선 확인
- [ ] Redis 중지 후 fallback 정상 동작 확인 (timeout 3초 적용 후 재검증)
- [ ] Redis 재시작 후 캐시 정상 복귀 확인

관련 이슈: #81