### PR TITLE
fix: CorsFilter에서 Origin 없는 비브라우저 요청 CORS 체크 스킵

### DIFF
--- a/src/main/java/kr/kakaotech/community/global/filter/CorsFilter.java
+++ b/src/main/java/kr/kakaotech/community/global/filter/CorsFilter.java
@@ -34,8 +34,14 @@ public class CorsFilter extends OncePerRequestFilter {
         String origin = request.getHeader("Origin");
         log.debug("[CorsFilter] Origin: {}, Method: {}, URI: {}", origin, request.getMethod(), uri);
 
+        // Origin이 없는 요청은 브라우저가 아닌 요청(서버 간 호출, 헬스체크, CLI 등)이므로 CORS 체크 스킵
+        if (origin == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         // origin이 허용 목록에 있으면 해당 origin을 설정
-        if (origin != null && corsProperties.getAllowedOrigins().contains(origin)) {
+        if (corsProperties.getAllowedOrigins().contains(origin)) {
             response.setHeader("Access-Control-Allow-Origin", origin);
             response.setHeader("Access-Control-Allow-Credentials", "true");
             response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
@@ -47,7 +53,7 @@ public class CorsFilter extends OncePerRequestFilter {
 
             log.debug("[CorsFilter] CORS headers added for origin: {}", origin);
         } else {
-            log.warn("[CorsFilter] Origin not allowed or missing: {}", origin);
+            log.warn("[CorsFilter] Origin not allowed: {}", origin);
         }
 
         // OPTIONS 요청은 여기서 바로 응답


### PR DESCRIPTION
## Summary
- Origin 헤더가 없는 비브라우저 요청(서버 간 호출, 헬스체크, k6 부하테스트, CLI 등)은 CORS 검증 없이 통과하도록 수정
- Origin이 있지만 허용 목록에 없는 경우에만 WARN 로그 출력
- 불필요한 WARN 로그 오염 방지

## Test plan
- [ ] Origin 없는 요청(curl, k6 등)에서 WARN 로그가 찍히지 않는지 확인
- [ ] 브라우저에서 허용된 Origin으로 요청 시 CORS 헤더 정상 응답 확인
- [ ] 브라우저에서 허용되지 않은 Origin으로 요청 시 WARN 로그 출력 확인