### PR TITLE
✅ test: Like 동시성 재현 테스트 추가

### DIFF
--- a/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -52,32 +54,38 @@ class LikeConcurrencyTest {
     @Autowired PostRepository postRepository;
     @Autowired PostStatusRepository postStatusRepository;
     @Autowired LikeRepository likeRepository;
+    @Autowired PlatformTransactionManager txManager;
 
     private UUID userId;
     private int postId;
 
     @BeforeEach
     void setUp() {
-        User user = new User("like-test@example.com", "password", "likeTester", "USER");
-        userRepository.save(user);
-        userId = user.getId();
+        // setUp 전체를 하나의 트랜잭션으로 묶어야 @MapsId 관계가 managed 상태에서 persist된다.
+        // (repository.save()를 연달아 호출하면 각각 별도 트랜잭션이 되어 detached 참조 문제 발생)
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+        tx.executeWithoutResult(s -> {
+            User user = new User("like-test@example.com", "password", "likeTester", "USER");
+            userRepository.save(user);
+            userId = user.getId();
 
-        Post post = new Post(
-                "동시성 테스트 게시글",
-                "content",
-                PostType.IN_PROGRESS,
-                user.getNickname(),
-                LocalDateTime.now(),
-                false,
-                user
-        );
-        postRepository.save(post);
-        postId = post.getId();
+            Post post = new Post(
+                    "동시성 테스트 게시글",
+                    "content",
+                    PostType.IN_PROGRESS,
+                    user.getNickname(),
+                    LocalDateTime.now(),
+                    false,
+                    user
+            );
+            postRepository.save(post);
+            postId = post.getId();
 
-        PostStatus status = new PostStatus(post);
-        postStatusRepository.save(status);
+            PostStatus status = new PostStatus(post);
+            postStatusRepository.save(status);
+        });
 
-        // 초기 상태: 좋아요 1개 등록
+        // 초기 상태: 좋아요 1개 등록 (별도 트랜잭션)
         likeService.toggleLike(userId, postId);
     }
 

--- a/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
@@ -1,0 +1,134 @@
+package kr.kakaotech.community.service;
+
+import kr.kakaotech.community.entity.Post;
+import kr.kakaotech.community.entity.PostStatus;
+import kr.kakaotech.community.entity.PostType;
+import kr.kakaotech.community.entity.User;
+import kr.kakaotech.community.repository.LikeRepository;
+import kr.kakaotech.community.repository.PostRepository;
+import kr.kakaotech.community.repository.PostStatusRepository;
+import kr.kakaotech.community.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * LikeService.toggleLike() 의 동시성 문제를 재현/검증하는 통합 테스트.
+ *
+ * <p>핵심 시나리오: 시나리오 2 — 동시 더블 취소
+ * <pre>
+ *   초기 상태: userA가 postX에 좋아요를 누른 상태 (row 1개, like_count=1)
+ *   N개 스레드가 동시에 toggleLike(userA, postX) 호출
+ *   → 모두 "있음 → 취소" 경로로 진입
+ *   → delete는 1번만 실제로 일어나지만 decrement가 N번 실행
+ *   → like_count ≠ 실제 row 수 (정합성 깨짐)
+ * </pre>
+ *
+ * <p>주의:
+ * <ul>
+ *   <li>테스트 클래스에 {@code @Transactional}을 붙이면 모든 스레드가 단일 트랜잭션을 공유하게 되어
+ *       동시성이 사라진다. 따라서 사용하지 않고 {@link #tearDown()}에서 수동 cleanup한다.</li>
+ *   <li>H2(MODE=MySQL)에서도 check-then-act race는 재현된다.</li>
+ * </ul>
+ */
+@SpringBootTest
+class LikeConcurrencyTest {
+
+    @Autowired LikeService likeService;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired PostStatusRepository postStatusRepository;
+    @Autowired LikeRepository likeRepository;
+
+    private UUID userId;
+    private int postId;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User("like-test@example.com", "password", "likeTester", "USER");
+        userRepository.save(user);
+        userId = user.getId();
+
+        Post post = new Post(
+                "동시성 테스트 게시글",
+                "content",
+                PostType.IN_PROGRESS,
+                user.getNickname(),
+                LocalDateTime.now(),
+                false,
+                user
+        );
+        postRepository.save(post);
+        postId = post.getId();
+
+        PostStatus status = new PostStatus(post);
+        postStatusRepository.save(status);
+
+        // 초기 상태: 좋아요 1개 등록
+        likeService.toggleLike(userId, postId);
+    }
+
+    @AfterEach
+    void tearDown() {
+        likeRepository.deleteAll();
+        postStatusRepository.deleteAll();
+        postRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("시나리오 2: 동시 더블 취소 시 like_count와 실제 row 수가 일치해야 한다")
+    void 동시_더블_취소_정합성() throws InterruptedException {
+        // given: setUp에서 좋아요 1개가 이미 등록된 상태
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // when: N개 스레드가 동시에 toggleLike 호출 (모두 취소 경로 진입 예상)
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    likeService.toggleLike(userId, postId);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // 모든 스레드 동시 출발
+        doneLatch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        // then: like_count와 실제 post_likes row 수가 일치해야 한다
+        int actualRows = likeRepository.countByPost_Id(postId);
+        int likeCount = postStatusRepository.findById(postId).orElseThrow().getLikeCount();
+
+        System.out.println("[결과] successCount=" + successCount + ", failCount=" + failCount);
+        System.out.println("[결과] actualRows=" + actualRows + ", likeCount=" + likeCount);
+
+        assertThat(likeCount)
+                .as("like_count는 실제 post_likes row 수와 일치해야 한다")
+                .isEqualTo(actualRows);
+    }
+}


### PR DESCRIPTION
## 배경

`LikeService.toggleLike()`는 check-then-act 패턴으로 동작하여 동시 요청 시 race condition이 존재한다. 해결에 앞서 **문제를 먼저 재현 가능하게 고정**하기 위한 통합 테스트를 추가한다.

관련 이슈: #84

## 변경 사항

- `LikeConcurrencyTest` 추가
  - 시나리오 2(동시 더블 취소) 재현 대상
  - `ExecutorService` + `CountDownLatch`로 동일 `(user, post)`에 N개 스레드 동시 호출
  - 검증: `like_count == 실제 post_likes row 수`
- setUp에서 `TransactionTemplate`으로 엔티티 생성을 단일 트랜잭션으로 묶음
  - 이유: 테스트 클래스에 `@Transactional`을 붙이면 모든 스레드가 단일 트랜잭션을 공유해 동시성이 사라짐
  - 그렇다고 안 붙이면 `@MapsId` 관계의 `PostStatus` 저장 시 detached entity 문제 발생
  - `TransactionTemplate`으로 setUp만 트랜잭션으로 감싸고 테스트 본문은 non-transactional 유지

## 현재 상태

- H2(`MODE=MySQL`) 환경에서 테스트 실행 시 정합성 깨짐이 재현되지 않음
  - 10개 스레드 중 1개만 성공, 9개는 예외로 실패하여 결과적으로 `like_count == row 수`가 유지됨
  - H2의 락/타임아웃 동작이 MySQL과 달라 race 구간이 자동으로 직렬화되는 것으로 추정
- 다음 작업에서 실패 원인 로깅 후 필요시 **MySQL Testcontainers**로 전환 예정

## Test plan

- [x] `./gradlew test --tests LikeConcurrencyTest` 실행 확인
- [ ] 실패 원인 로깅 추가 후 H2 재현 가능 여부 재확인
- [ ] 필요 시 MySQL Testcontainers 도입
- [ ] 비관적 락 적용 후 동일 테스트로 정합성 보장 검증