### PR TITLE
test: 주요 API N+1 회귀 테스트 추가

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4.8
     container_name: community-mysql
     restart: unless-stopped
     environment:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: community-mysql
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8.4
+    image: mysql:8.4.8
     container_name: community-mysql
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/src/main/java/kr/kakaotech/community/auth/AuthFilter.java
+++ b/src/main/java/kr/kakaotech/community/auth/AuthFilter.java
@@ -84,7 +84,7 @@ public class AuthFilter extends OncePerRequestFilter {
                 authExceptionHandler(response, new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN));
                 return;
             } else {
-                if (requestURI.matches(LIKE_URL)) {
+                if ("GET".equals(request.getMethod()) && requestURI.matches(LIKE_URL)) {
                     filterChain.doFilter(request, response);
                     return;
                 }

--- a/src/main/java/kr/kakaotech/community/controller/AuthController.java
+++ b/src/main/java/kr/kakaotech/community/controller/AuthController.java
@@ -44,7 +44,6 @@ public class AuthController {
     @GetMapping("/auth/refresh")
     public ResponseEntity<ApiResponse<Object>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
         authService.refreshToken(request, response);
-        ApiResponse.success("success", true);
-        return null;
+        return ApiResponse.success("success", true);
     }
 }

--- a/src/main/java/kr/kakaotech/community/controller/UserController.java
+++ b/src/main/java/kr/kakaotech/community/controller/UserController.java
@@ -10,6 +10,8 @@ import kr.kakaotech.community.dto.request.UserPasswordRequest;
 import kr.kakaotech.community.dto.request.UserRegisterRequest;
 import kr.kakaotech.community.dto.request.UserUpdateRequest;
 import kr.kakaotech.community.dto.response.UserDetailResponse;
+import kr.kakaotech.community.exception.CustomException;
+import kr.kakaotech.community.exception.ErrorCode;
 import kr.kakaotech.community.service.AuthService;
 import kr.kakaotech.community.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -65,6 +67,10 @@ public class UserController {
                                                                       @Valid @ModelAttribute UserUpdateRequest userUpdateRequest,
                                                                       @RequestPart(value = "profileImage", required = false) MultipartFile image,
                                                                       HttpServletRequest request) {
+        if (!userId.equals(request.getAttribute("userId").toString())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
         UserDetailResponse userDetailResponse = userService.updateUser(userId, userUpdateRequest, image);
 
         ApiResponse<UserDetailResponse> apiResponse = new ApiResponse<>("업데이트 성공", userDetailResponse);

--- a/src/main/java/kr/kakaotech/community/repository/CommentRepository.java
+++ b/src/main/java/kr/kakaotech/community/repository/CommentRepository.java
@@ -4,10 +4,12 @@ import kr.kakaotech.community.entity.Comment;
 import kr.kakaotech.community.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 
 public interface CommentRepository extends JpaRepository<Comment, Integer> {
+    @EntityGraph(attributePaths = "user")
     Page<Comment> findByPost(Post post, Pageable pageable);
 }

--- a/src/main/java/kr/kakaotech/community/repository/PostStatusRepository.java
+++ b/src/main/java/kr/kakaotech/community/repository/PostStatusRepository.java
@@ -20,7 +20,7 @@ public interface PostStatusRepository extends JpaRepository<PostStatus, Integer>
     @Query("SELECT p FROM post_statuses p WHERE p.postId = :id")
     Optional<PostStatus> findByIdForUpdate(@Param("id") int id);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
         UPDATE post_statuses
         SET view_count = view_count + 1
@@ -28,7 +28,7 @@ public interface PostStatusRepository extends JpaRepository<PostStatus, Integer>
     """, nativeQuery = true)
     void incrementViewCount(@Param("id") int id);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
         UPDATE post_statuses
         SET like_count = like_count + 1
@@ -36,7 +36,7 @@ public interface PostStatusRepository extends JpaRepository<PostStatus, Integer>
     """, nativeQuery = true)
     void incrementLikeCount(@Param("id") int id);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
         UPDATE post_statuses
         SET like_count = like_count - 1
@@ -44,7 +44,7 @@ public interface PostStatusRepository extends JpaRepository<PostStatus, Integer>
     """, nativeQuery = true)
     void decrementLikeCount(@Param("id") int id);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
         UPDATE post_statuses
         SET comment_count = comment_count + 1
@@ -52,7 +52,7 @@ public interface PostStatusRepository extends JpaRepository<PostStatus, Integer>
     """, nativeQuery = true)
     void incrementCommentCount(@Param("id") int id);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
         UPDATE post_statuses
         SET comment_count = GREATEST(comment_count - 1, 0)

--- a/src/main/java/kr/kakaotech/community/repository/PostStatusRepository.java
+++ b/src/main/java/kr/kakaotech/community/repository/PostStatusRepository.java
@@ -1,7 +1,9 @@
 package kr.kakaotech.community.repository;
 
+import jakarta.persistence.LockModeType;
 import kr.kakaotech.community.entity.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,14 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface PostStatusRepository extends JpaRepository<PostStatus, Integer> {
+
+    /**
+     * 좋아요 토글 등 check-then-act 임계 구역의 진입 락.
+     * PostStatus 행에 PESSIMISTIC_WRITE 락을 걸어 같은 게시글에 대한 동시 토글을 직렬화한다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM post_statuses p WHERE p.postId = :id")
+    Optional<PostStatus> findByIdForUpdate(@Param("id") int id);
 
     @Modifying
     @Query(value = """

--- a/src/main/java/kr/kakaotech/community/repository/UserRepository.java
+++ b/src/main/java/kr/kakaotech/community/repository/UserRepository.java
@@ -1,6 +1,9 @@
 package kr.kakaotech.community.repository;
 
 import kr.kakaotech.community.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +12,10 @@ import java.util.UUID;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
+    @Override
+    @EntityGraph(attributePaths = "image")
+    Page<User> findAll(Pageable pageable);
+
     boolean existsByNickname(String nickname);
 
     boolean existsByEmail(String email);

--- a/src/main/java/kr/kakaotech/community/service/JWTAuthService.java
+++ b/src/main/java/kr/kakaotech/community/service/JWTAuthService.java
@@ -58,6 +58,7 @@ public class JWTAuthService implements AuthService {
 
         // 기존 리프레시 토큰 무효화
         refreshTokenRepository.deleteByUserId(user.getId());
+        refreshTokenRepository.flush();
 
         // 토큰 발급 및 저장
         TokenResponse tokenResponse = generateAndSaveToken(user);
@@ -116,6 +117,7 @@ public class JWTAuthService implements AuthService {
 
         // 해당 유저에 대한 모든 토큰 삭제
         refreshTokenRepository.deleteByUserId(UUID.fromString(userId));
+        refreshTokenRepository.flush();
 
         // 쿠키 재발급(Access + Refresh, Refresh DB 등록)
         User user = userRepository.findById(UUID.fromString(userId)).get();

--- a/src/main/java/kr/kakaotech/community/service/LikeService.java
+++ b/src/main/java/kr/kakaotech/community/service/LikeService.java
@@ -31,6 +31,11 @@ public class LikeService {
 
     @Transactional
     public LikeResponse toggleLike(UUID userId, int postId) {
+        // PostStatus 행에 PESSIMISTIC_WRITE 락을 획득해 같은 게시글에 대한 동시 토글을 직렬화한다.
+        // 가용성 문제(StaleObjectStateException 다발) 해결이 목적.
+        postStatusRepository.findByIdForUpdate(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+
         Optional<PostLike> optionalPostLike = likeRepository.findByUser_IdAndPost_Id(userId, postId);
 
         // 좋아요 취소

--- a/src/main/java/kr/kakaotech/community/service/PostService.java
+++ b/src/main/java/kr/kakaotech/community/service/PostService.java
@@ -227,6 +227,9 @@ public class PostService {
         if (post.getDeleted()) {
             throw new CustomException(ErrorCode.NOT_FOUND_POST);
         }
+        if (!post.getUser().getId().toString().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
 
         post.deletePost();
     }

--- a/src/test/java/kr/kakaotech/community/integration/ApiFunctionalIntegrationTest.java
+++ b/src/test/java/kr/kakaotech/community/integration/ApiFunctionalIntegrationTest.java
@@ -1,0 +1,602 @@
+package kr.kakaotech.community.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.servlet.http.Cookie;
+import kr.kakaotech.community.auth.jwt.JwtProvider;
+import kr.kakaotech.community.entity.Comment;
+import kr.kakaotech.community.entity.Post;
+import kr.kakaotech.community.entity.PostStatus;
+import kr.kakaotech.community.entity.PostType;
+import kr.kakaotech.community.entity.User;
+import kr.kakaotech.community.repository.CommentRepository;
+import kr.kakaotech.community.repository.LikeRepository;
+import kr.kakaotech.community.repository.PostRepository;
+import kr.kakaotech.community.repository.PostStatusRepository;
+import kr.kakaotech.community.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ApiFunctionalIntegrationTest {
+
+    private static final String PASSWORD = "Aa123456!";
+    private static final String NEW_PASSWORD = "Bb123456!";
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired PostStatusRepository postStatusRepository;
+    @Autowired CommentRepository commentRepository;
+    @Autowired LikeRepository likeRepository;
+    @Autowired JwtProvider jwtProvider;
+    @Autowired PasswordEncoder passwordEncoder;
+    @PersistenceContext EntityManager em;
+
+    @Test
+    @DisplayName("POST /auth — 로그인 성공 시 토큰 쿠키를 발급한다")
+    void login_success() throws Exception {
+        User user = saveUser("lo");
+
+        mockMvc.perform(post("/api/auth")
+                        .contextPath("/api")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("email", user.getEmail(), "password", PASSWORD))))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("accessToken"))
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(jsonPath("$.message").value("로그인 성공"))
+                .andExpect(jsonPath("$.data.userEmail").value(user.getEmail()));
+    }
+
+    @Test
+    @DisplayName("POST /auth — 비밀번호가 틀리면 400을 반환한다")
+    void login_fail_badPassword() throws Exception {
+        User user = saveUser("lf");
+
+        mockMvc.perform(post("/api/auth")
+                        .contextPath("/api")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("email", user.getEmail(), "password", "wrong"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("GET /auth/refresh — refreshToken이 유효하면 새 토큰 쿠키를 발급한다")
+    void refreshToken_success() throws Exception {
+        User user = saveUser("rf");
+        Cookie[] cookies = loginCookies(user);
+
+        mockMvc.perform(get("/api/auth/refresh")
+                        .contextPath("/api")
+                        .cookie(cookies))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("accessToken"))
+                .andExpect(cookie().exists("refreshToken"))
+                .andExpect(jsonPath("$.data").value(true));
+    }
+
+    @Test
+    @DisplayName("POST /auth/token — 로그아웃 성공 시 refreshToken을 폐기한다")
+    void logout_success() throws Exception {
+        User user = saveUser("lg");
+        Cookie[] cookies = loginCookies(user);
+
+        mockMvc.perform(post("/api/auth/token")
+                        .contextPath("/api")
+                        .cookie(cookies))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("accessToken", 0))
+                .andExpect(cookie().maxAge("refreshToken", 0));
+    }
+
+    @Test
+    @DisplayName("POST /users — 회원가입 성공 시 사용자를 생성한다")
+    void registerUser_success() throws Exception {
+        String suffix = suffix();
+        String email = "join-" + suffix + "@test.com";
+
+        mockMvc.perform(multipart("/api/users")
+                        .contextPath("/api")
+                        .param("email", email)
+                        .param("nickname", "jn" + suffix)
+                        .param("password", PASSWORD)
+                        .param("role", "USER"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data").value(email));
+
+        flushAndClear();
+        assertThat(userRepository.existsByEmail(email)).isTrue();
+    }
+
+    @Test
+    @DisplayName("POST /users — 중복 이메일이면 409를 반환한다")
+    void registerUser_fail_duplicateEmail() throws Exception {
+        User user = saveUser("du");
+
+        mockMvc.perform(multipart("/api/users")
+                        .contextPath("/api")
+                        .param("email", user.getEmail())
+                        .param("nickname", "du" + suffix())
+                        .param("password", PASSWORD)
+                        .param("role", "USER"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("PATCH /users/{id} — 본인 닉네임을 수정한다")
+    void updateUser_success() throws Exception {
+        User user = saveUser("uu");
+
+        mockMvc.perform(patchMultipart("/api/users/{userId}", user.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(user))
+                        .param("nickname", "newnick"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("newnick"));
+
+        flushAndClear();
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getNickname()).isEqualTo("newnick");
+    }
+
+    @Test
+    @DisplayName("PATCH /users/{id} — 다른 회원 수정은 403을 반환한다")
+    void updateUser_fail_forbidden() throws Exception {
+        User owner = saveUser("uo");
+        User attacker = saveUser("ua");
+
+        mockMvc.perform(patchMultipart("/api/users/{userId}", owner.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(attacker))
+                        .param("nickname", "hacked"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("PATCH /users/password — 비밀번호를 변경하고 토큰을 폐기한다")
+    void changePassword_success() throws Exception {
+        User user = saveUser("pw");
+        Cookie[] cookies = loginCookies(user);
+
+        mockMvc.perform(patch("/api/users/password")
+                        .contextPath("/api")
+                        .cookie(cookies)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("currentPassword", PASSWORD, "newPassword", NEW_PASSWORD))))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("accessToken", 0))
+                .andExpect(cookie().maxAge("refreshToken", 0))
+                .andExpect(jsonPath("$.data").value(true));
+
+        flushAndClear();
+        String encodedPassword = userRepository.findById(user.getId()).orElseThrow().getPassword();
+        assertThat(passwordEncoder.matches(NEW_PASSWORD, encodedPassword)).isTrue();
+    }
+
+    @Test
+    @DisplayName("PATCH /users/password — 현재 비밀번호가 틀리면 400을 반환한다")
+    void changePassword_fail_badPassword() throws Exception {
+        User user = saveUser("pf");
+
+        mockMvc.perform(patch("/api/users/password")
+                        .contextPath("/api")
+                        .cookie(accessCookie(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("currentPassword", "wrong", "newPassword", NEW_PASSWORD))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH /users/{id}/deactivation — 회원을 소프트 삭제한다")
+    void deactivateUser_success() throws Exception {
+        User user = saveUser("wd");
+        Cookie[] cookies = loginCookies(user);
+
+        mockMvc.perform(patch("/api/users/{userId}/deactivation", user.getId())
+                        .contextPath("/api")
+                        .cookie(cookies)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("currentPassword", PASSWORD, "newPassword", NEW_PASSWORD))))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge("accessToken", 0))
+                .andExpect(cookie().maxAge("refreshToken", 0));
+
+        flushAndClear();
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("POST /posts — 게시글을 생성하고 PostStatus를 생성한다")
+    void registerPost_success() throws Exception {
+        User user = saveUser("po");
+
+        MvcResult result = mockMvc.perform(multipart("/api/posts")
+                        .contextPath("/api")
+                        .cookie(accessCookie(user))
+                        .param("title", "새 게시글")
+                        .param("content", "내용")
+                        .param("type", "IN_PROGRESS"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("게시글 등록 성공"))
+                .andReturn();
+
+        int postId = jsonNode(result).path("data").asInt();
+        flushAndClear();
+        assertThat(postRepository.findById(postId)).isPresent();
+        assertThat(postStatusRepository.findById(postId)).isPresent();
+    }
+
+    @Test
+    @DisplayName("POST /posts — 인증이 없으면 401을 반환한다")
+    void registerPost_fail_unauthorized() throws Exception {
+        mockMvc.perform(multipart("/api/posts")
+                        .contextPath("/api")
+                        .param("title", "새 게시글")
+                        .param("content", "내용")
+                        .param("type", "IN_PROGRESS"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("PATCH /posts/{id} — 작성자는 게시글을 수정할 수 있다")
+    void updatePost_success() throws Exception {
+        User author = saveUser("pa");
+        Post post = savePost(author);
+
+        mockMvc.perform(patchMultipart("/api/posts/{postId}", post.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(author))
+                        .param("title", "수정 제목")
+                        .param("content", "수정 내용")
+                        .param("type", "COMPLETED"))
+                .andExpect(status().isOk());
+
+        flushAndClear();
+        Post updated = postRepository.findById(post.getId()).orElseThrow();
+        assertThat(updated.getTitle()).isEqualTo("수정 제목");
+        assertThat(updated.getType()).isEqualTo(PostType.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("PATCH /posts/{id} — 작성자가 아니면 403을 반환한다")
+    void updatePost_fail_forbidden() throws Exception {
+        User author = saveUser("pb");
+        User attacker = saveUser("pc");
+        Post post = savePost(author);
+
+        mockMvc.perform(patchMultipart("/api/posts/{postId}", post.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(attacker))
+                        .param("title", "수정 제목")
+                        .param("content", "수정 내용")
+                        .param("type", "COMPLETED"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("PATCH /posts/{id}/deactivation — 작성자는 게시글을 삭제할 수 있다")
+    void deactivatePost_success() throws Exception {
+        User author = saveUser("pd");
+        Post post = savePost(author);
+
+        mockMvc.perform(patch("/api/posts/{postId}/deactivation", post.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(author)))
+                .andExpect(status().isOk());
+
+        flushAndClear();
+        assertThat(postRepository.findById(post.getId()).orElseThrow().getDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("PATCH /posts/{id}/deactivation — 작성자가 아니면 403을 반환한다")
+    void deactivatePost_fail_forbidden() throws Exception {
+        User author = saveUser("pe");
+        User attacker = saveUser("px");
+        Post post = savePost(author);
+
+        mockMvc.perform(patch("/api/posts/{postId}/deactivation", post.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(attacker)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("GET /posts — 잘못된 기간 필터는 400을 반환한다")
+    void getPosts_fail_invalidPeriod() throws Exception {
+        mockMvc.perform(get("/api/posts")
+                        .contextPath("/api")
+                        .param("period", "monthly"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /posts/{id}/comments — 댓글을 생성하고 댓글 수를 증가시킨다")
+    void registerComment_success() throws Exception {
+        User author = saveUser("ca");
+        User commenter = saveUser("cb");
+        Post post = savePost(author);
+        long beforeCount = commentRepository.count();
+
+        mockMvc.perform(post("/api/posts/{postId}/comments", post.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(commenter))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("content", "댓글입니다"))))
+                .andExpect(status().isCreated());
+
+        flushAndClear();
+        assertThat(commentRepository.count()).isEqualTo(beforeCount + 1);
+        assertThat(postStatusRepository.findById(post.getId()).orElseThrow().getCommentCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("POST /posts/{id}/comments — 없는 게시글이면 404를 반환한다")
+    void registerComment_fail_postNotFound() throws Exception {
+        User user = saveUser("cf");
+
+        mockMvc.perform(post("/api/posts/{postId}/comments", missingPostId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("content", "댓글입니다"))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PATCH /comments/{id} — 작성자는 댓글을 수정할 수 있다")
+    void updateComment_success() throws Exception {
+        User author = saveUser("cc");
+        Post post = savePost(author);
+        Comment comment = saveComment(author, post);
+
+        mockMvc.perform(patch("/api/comments/{commentId}", comment.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(author))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("content", "수정 댓글"))))
+                .andExpect(status().isOk());
+
+        flushAndClear();
+        assertThat(commentRepository.findById(comment.getId()).orElseThrow().getContent()).isEqualTo("수정 댓글");
+    }
+
+    @Test
+    @DisplayName("PATCH /comments/{id} — 작성자가 아니면 403을 반환한다")
+    void updateComment_fail_forbidden() throws Exception {
+        User author = saveUser("cd");
+        User attacker = saveUser("ce");
+        Post post = savePost(author);
+        Comment comment = saveComment(author, post);
+
+        mockMvc.perform(patch("/api/comments/{commentId}", comment.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(attacker))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("content", "수정 댓글"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("PATCH /comments/{id}/deactivation — 작성자는 댓글을 삭제할 수 있다")
+    void deactivateComment_success() throws Exception {
+        User author = saveUser("ci");
+        Post post = savePost(author);
+        Comment comment = saveComment(author, post);
+
+        mockMvc.perform(patch("/api/comments/{commentId}/deactivation", comment.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(author)))
+                .andExpect(status().isOk());
+
+        flushAndClear();
+        assertThat(commentRepository.findById(comment.getId()).orElseThrow().getDeleted()).isTrue();
+        assertThat(postStatusRepository.findById(post.getId()).orElseThrow().getCommentCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("POST /posts/{id}/likes — 좋아요를 토글한다")
+    void toggleLike_success() throws Exception {
+        User author = saveUser("la");
+        User user = saveUser("lb");
+        Post post = savePost(author);
+
+        mockMvc.perform(post("/api/posts/{postId}/likes", post.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.likeStatus").value(true))
+                .andExpect(jsonPath("$.data.likeCount").value(1));
+
+        mockMvc.perform(post("/api/posts/{postId}/likes", post.getId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.likeStatus").value(false))
+                .andExpect(jsonPath("$.data.likeCount").value(0));
+
+        flushAndClear();
+        assertThat(likeRepository.countByPost_Id(post.getId())).isZero();
+        assertThat(postStatusRepository.findById(post.getId()).orElseThrow().getLikeCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("POST /posts/{id}/likes — 인증이 없으면 401을 반환한다")
+    void toggleLike_fail_unauthorized() throws Exception {
+        User author = saveUser("lc");
+        Post post = savePost(author);
+
+        mockMvc.perform(post("/api/posts/{postId}/likes", post.getId())
+                        .contextPath("/api"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /posts/{id}/likes — 없는 게시글이면 404를 반환한다")
+    void toggleLike_fail_postNotFound() throws Exception {
+        User user = saveUser("ld");
+
+        mockMvc.perform(post("/api/posts/{postId}/likes", missingPostId())
+                        .contextPath("/api")
+                        .cookie(accessCookie(user)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /posts/{id}/likes — 비로그인 사용자는 좋아요 상태 false를 받는다")
+    void getLikeStatus_success_anonymous() throws Exception {
+        User author = saveUser("le");
+        Post post = savePost(author);
+
+        mockMvc.perform(get("/api/posts/{postId}/likes", post.getId())
+                        .contextPath("/api"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.likeStatus").value(false))
+                .andExpect(jsonPath("$.data.likeCount").value(0));
+    }
+
+    @Test
+    @DisplayName("POST /images — 이미지가 아닌 파일이면 400을 반환한다")
+    void uploadImage_fail_badContentType() throws Exception {
+        MockMultipartFile textFile = new MockMultipartFile(
+                "images",
+                "test.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "not-image".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/images")
+                        .file(textFile)
+                        .contextPath("/api"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private User saveUser(String prefix) {
+        String suffix = suffix();
+        User user = new User(
+                prefix + "-" + suffix + "@test.com",
+                passwordEncoder.encode(PASSWORD),
+                prefix + suffix,
+                "USER"
+        );
+        return userRepository.saveAndFlush(user);
+    }
+
+    private Post savePost(User user) {
+        Post post = new Post(
+                "제목 " + suffix(),
+                "내용",
+                PostType.IN_PROGRESS,
+                user.getNickname(),
+                LocalDateTime.now(),
+                false,
+                user
+        );
+        Post savedPost = postRepository.saveAndFlush(post);
+        postStatusRepository.saveAndFlush(new PostStatus(savedPost));
+        return savedPost;
+    }
+
+    private Comment saveComment(User user, Post post) {
+        Comment comment = commentRepository.saveAndFlush(new Comment("댓글", user, post));
+        postStatusRepository.incrementCommentCount(post.getId());
+        flushAndClear();
+        return comment;
+    }
+
+    private Cookie accessCookie(User user) {
+        Cookie cookie = new Cookie("accessToken", jwtProvider.createAccess(user.getId().toString(), "USER"));
+        cookie.setPath("/");
+        return cookie;
+    }
+
+    private Cookie[] loginCookies(User user) throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/auth")
+                        .contextPath("/api")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json(Map.of("email", user.getEmail(), "password", PASSWORD))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Cookie accessToken = findCookie(result, "accessToken");
+        Cookie refreshToken = findCookie(result, "refreshToken");
+        return new Cookie[] {accessToken, refreshToken};
+    }
+
+    private Cookie findCookie(MvcResult result, String name) {
+        return Arrays.stream(result.getResponse().getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private String json(Object value) throws Exception {
+        return objectMapper.writeValueAsString(value);
+    }
+
+    private JsonNode jsonNode(MvcResult result) throws Exception {
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private MockMultipartHttpServletRequestBuilder patchMultipart(String urlTemplate, Object... uriVars) {
+        MockMultipartHttpServletRequestBuilder builder = multipart(urlTemplate, uriVars);
+        builder.with(patchMethod());
+        return builder;
+    }
+
+    private RequestPostProcessor patchMethod() {
+        return request -> {
+            request.setMethod("PATCH");
+            return request;
+        };
+    }
+
+    private void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+    private String suffix() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+    private int missingPostId() {
+        int candidate = Integer.MAX_VALUE;
+        while (postRepository.existsById(candidate)) {
+            candidate--;
+        }
+        return candidate;
+    }
+}

--- a/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
+++ b/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
@@ -127,6 +127,10 @@ class NPlusOneIntegrationTest extends NPlusOneTestSupport {
         // requestURI는 /api/... 로 유지하고 servlet dispatch는 /posts 경로로 되도록 contextPath 사용.
         // 인증 필요한 엔드포인트 대비 JWT 쿠키도 항상 동봉.
         MvcResult result = mockMvc.perform(get("/api" + url).contextPath("/api").cookie(authCookie)).andReturn();
+        assertThat(result.getResponse().getStatus())
+                .as(url + " 응답 status는 2xx여야 한다")
+                .isBetween(200, 299);
+
         String header = result.getResponse().getHeader(NPlusOneTestSupport.QUERY_COUNT_HEADER);
         assertThat(header)
                 .as("테스트 필터가 X-Query-Count 헤더를 설정해야 한다")

--- a/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
+++ b/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
@@ -1,0 +1,192 @@
+package kr.kakaotech.community.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.servlet.http.Cookie;
+import kr.kakaotech.community.auth.jwt.JwtProvider;
+import kr.kakaotech.community.entity.Comment;
+import kr.kakaotech.community.entity.Post;
+import kr.kakaotech.community.entity.PostStatus;
+import kr.kakaotech.community.entity.PostType;
+import kr.kakaotech.community.entity.User;
+import kr.kakaotech.community.repository.CommentRepository;
+import kr.kakaotech.community.repository.PostRepository;
+import kr.kakaotech.community.repository.PostStatusRepository;
+import kr.kakaotech.community.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+/**
+ * N+1 감지용 통합 테스트.
+ *
+ * <p>각 테스트는 MockMvc로 실제 API 엔드포인트를 호출하고, 응답 헤더 {@code X-Query-Count}에서
+ * 해당 요청 동안 실행된 SQL 쿼리 수를 읽어 하드 단언한다. 임계값은 "데이터 건수와 무관하게
+ * 일정 수준을 넘지 않아야 한다"는 N+1 부재 조건으로 설정한다.
+ *
+ * <p>{@code @Transactional}로 테스트 자동 롤백 — seed 데이터는 테스트 범위에서만 살아있다가
+ * 종료 시 사라진다. 서비스의 {@code @Transactional(readOnly=true)}는 테스트 트랜잭션에
+ * (propagation REQUIRED) 참여하므로 MockMvc 요청이 seed 데이터를 볼 수 있다.
+ */
+@Transactional
+class NPlusOneIntegrationTest extends NPlusOneTestSupport {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired PostStatusRepository postStatusRepository;
+    @Autowired CommentRepository commentRepository;
+    @Autowired RedisTemplate<String, Object> redisTemplate;
+    @Autowired JwtProvider jwtProvider;
+    @PersistenceContext EntityManager em;
+
+    private Cookie authCookie;
+
+    private static final String TOP10_CACHE_KEY = "posts:top10";
+    private static final int COMMENT_SEED_COUNT = 5;
+
+    private int targetPostId;
+
+    @BeforeEach
+    void seed() {
+        // Top10 캐시 flush (미스 경로 보장)
+        redisTemplate.delete(TOP10_CACHE_KEY);
+
+        // 닉네임은 12자 제한, UUID 앞 8자 사용 ("np1_" + 8자 = 12자)
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        User author = new User(
+                "nplus1-" + suffix + "@test.com",
+                "pw",
+                "np1_" + suffix,
+                "USER"
+        );
+        userRepository.saveAndFlush(author);
+
+        String accessToken = jwtProvider.createAccess(author.getId().toString(), "USER");
+        authCookie = new Cookie("accessToken", accessToken);
+
+        List<Integer> seededPostIds = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Post post = new Post(
+                    "N+1 테스트 게시글 " + i,
+                    "content-" + i,
+                    PostType.COMPLETED,
+                    author.getNickname(),
+                    LocalDateTime.now().minusMinutes(i),
+                    false,
+                    author
+            );
+            postRepository.saveAndFlush(post);
+
+            postStatusRepository.saveAndFlush(new PostStatus(post));
+            seededPostIds.add(post.getId());
+        }
+
+        targetPostId = seededPostIds.get(0);
+
+        Post targetPost = postRepository.findById(targetPostId).orElseThrow();
+        // N+1 감지를 위해 댓글 작성자를 모두 다르게 생성한다. 같은 유저로 seed하면 Hibernate
+        // 1차 캐시가 lazy user 로딩을 덮어 N+1이 가려진다.
+        for (int i = 0; i < COMMENT_SEED_COUNT; i++) {
+            String s = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+            User commenter = new User("c-" + s + "@test.com", "pw", "c_" + s, "USER");
+            userRepository.saveAndFlush(commenter);
+            commentRepository.saveAndFlush(new Comment("댓글 " + i, commenter, targetPost));
+        }
+    }
+
+    private int callAndGetQueryCount(String url) throws Exception {
+        // @Transactional 테스트에서 seed 엔티티가 persistence context(L1 cache)에 남아 있으면
+        // lazy 관계도 캐시 히트로 처리되어 N+1이 가려진다. MockMvc 요청 전 flush + clear로
+        // 실제 콜드 상태에서 쿼리 수를 측정한다.
+        em.flush();
+        em.clear();
+
+        // AuthFilter가 /api 프리픽스 기준으로 인증 예외 경로를 매칭하므로,
+        // requestURI는 /api/... 로 유지하고 servlet dispatch는 /posts 경로로 되도록 contextPath 사용.
+        // 인증 필요한 엔드포인트 대비 JWT 쿠키도 항상 동봉.
+        MvcResult result = mockMvc.perform(get("/api" + url).contextPath("/api").cookie(authCookie)).andReturn();
+        String header = result.getResponse().getHeader(NPlusOneTestSupport.QUERY_COUNT_HEADER);
+        assertThat(header)
+                .as("테스트 필터가 X-Query-Count 헤더를 설정해야 한다")
+                .isNotNull();
+        int count = Integer.parseInt(header);
+        System.out.println("[QUERY-COUNT] " + url + " → " + count + " queries (status=" + result.getResponse().getStatus() + ")");
+        return count;
+    }
+
+    @Test
+    @DisplayName("GET /posts — 게시글 목록 조회는 최대 2 쿼리")
+    void getPostList_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts?size=5");
+
+        assertThat(count)
+                .as("projection 쿼리 단일 실행 기대. 초과 시 N+1 의심")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts/top10 — 인기글 조회(캐시 미스)는 최대 2 쿼리")
+    void getPostTop10_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts/top10");
+
+        assertThat(count)
+                .as("Redis 캐시 미스 시에도 단일 projection 쿼리로 충분해야 함")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts/index — 홈 인덱스 목록은 최대 2 쿼리")
+    void getPostIndex_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts/index");
+
+        assertThat(count)
+                .as("이미지 url 포함 projection 단일 쿼리 기대")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts/{id} — 상세 조회는 최대 2 쿼리")
+    void getPostDetail_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts/" + targetPostId);
+
+        assertThat(count)
+                .as("JOIN FETCH로 images/user 한번에 로딩 기대")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts/{id}/statuses — 통계 조회는 최대 2 쿼리")
+    void getPostStatuses_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts/" + targetPostId + "/statuses");
+
+        assertThat(count)
+                .as("findById 단일 쿼리 기대")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts/{id}/comments — 댓글 목록은 댓글 수와 무관하게 최대 4 쿼리")
+    void getCommentList_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts/" + targetPostId + "/comments");
+
+        // 현재 구현: findById(post) + count(comments) + find comments + N x lazy user → 3+N 쿼리
+        // 기대: user fetch join 적용 시 3~4 쿼리 고정 (댓글 수 증가와 무관해야 N+1 부재)
+        assertThat(count)
+                .as("댓글 수가 늘어도 쿼리 수가 증가하면 안 됨 (user fetch join 필요)")
+                .isLessThanOrEqualTo(4);
+    }
+}

--- a/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
+++ b/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
@@ -5,6 +5,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.servlet.http.Cookie;
 import kr.kakaotech.community.auth.jwt.JwtProvider;
 import kr.kakaotech.community.entity.Comment;
+import kr.kakaotech.community.entity.Image;
 import kr.kakaotech.community.entity.Post;
 import kr.kakaotech.community.entity.PostStatus;
 import kr.kakaotech.community.entity.PostType;
@@ -136,6 +137,24 @@ class NPlusOneIntegrationTest extends NPlusOneTestSupport {
         assertThat(count)
                 .as("projection 쿼리 단일 실행 기대. 초과 시 N+1 의심")
                 .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /users — 회원 목록 조회는 프로필 이미지 수와 무관하게 최대 3 쿼리")
+    void getUserList_nPlusOne() throws Exception {
+        // UserDetailResponse가 imageUrl을 읽으므로 프로필 이미지가 있는 유저를 여러 명 seed한다.
+        for (int i = 0; i < 5; i++) {
+            String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+            User user = new User("u-" + suffix + "@test.com", "pw", "u_" + suffix, "USER");
+            user.addImage(new Image("https://example.com/" + suffix + ".png"));
+            userRepository.saveAndFlush(user);
+        }
+
+        int count = callAndGetQueryCount("/users?size=5");
+
+        assertThat(count)
+                .as("회원 수만큼 프로필 이미지 조회가 추가되면 안 됨")
+                .isLessThanOrEqualTo(3);
     }
 
     @Test

--- a/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
+++ b/src/test/java/kr/kakaotech/community/integration/NPlusOneIntegrationTest.java
@@ -60,6 +60,9 @@ class NPlusOneIntegrationTest extends NPlusOneTestSupport {
     private static final int COMMENT_SEED_COUNT = 5;
 
     private int targetPostId;
+    private UUID authorId;
+    private String authorEmail;
+    private String authorNickname;
 
     @BeforeEach
     void seed() {
@@ -74,7 +77,11 @@ class NPlusOneIntegrationTest extends NPlusOneTestSupport {
                 "np1_" + suffix,
                 "USER"
         );
+        author.addImage(new Image("https://example.com/author-" + suffix + ".png"));
         userRepository.saveAndFlush(author);
+        authorId = author.getId();
+        authorEmail = author.getEmail();
+        authorNickname = author.getNickname();
 
         String accessToken = jwtProvider.createAccess(author.getId().toString(), "USER");
         authCookie = new Cookie("accessToken", accessToken);
@@ -140,6 +147,26 @@ class NPlusOneIntegrationTest extends NPlusOneTestSupport {
     }
 
     @Test
+    @DisplayName("GET /posts?period=daily — 기간별 인기글 목록은 최대 2 쿼리")
+    void getLikePostList_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts?period=daily&size=5");
+
+        assertThat(count)
+                .as("기간별 projection 쿼리 단일 실행 기대")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts?nickname=... — 작성자별 게시글 목록은 최대 2 쿼리")
+    void getNicknamePostList_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts?nickname=" + authorNickname + "&size=5");
+
+        assertThat(count)
+                .as("작성자별 projection 쿼리 단일 실행 기대")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
     @DisplayName("GET /users — 회원 목록 조회는 프로필 이미지 수와 무관하게 최대 3 쿼리")
     void getUserList_nPlusOne() throws Exception {
         // UserDetailResponse가 imageUrl을 읽으므로 프로필 이미지가 있는 유저를 여러 명 seed한다.
@@ -155,6 +182,36 @@ class NPlusOneIntegrationTest extends NPlusOneTestSupport {
         assertThat(count)
                 .as("회원 수만큼 프로필 이미지 조회가 추가되면 안 됨")
                 .isLessThanOrEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("GET /users/{id} — 회원 상세 조회는 최대 2 쿼리")
+    void getUserDetail_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/users/" + authorId);
+
+        assertThat(count)
+                .as("단일 회원 상세 조회는 고정 쿼리 수여야 함")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /users/email — 이메일 중복 확인은 최대 1 쿼리")
+    void checkUserEmail_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/users/email?email=" + authorEmail);
+
+        assertThat(count)
+                .as("이메일 exists 쿼리 단일 실행 기대")
+                .isLessThanOrEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("GET /users/nickname — 닉네임 중복 확인은 최대 1 쿼리")
+    void checkUserNickname_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/users/nickname?nickname=" + authorNickname);
+
+        assertThat(count)
+                .as("닉네임 exists 쿼리 단일 실행 기대")
+                .isLessThanOrEqualTo(1);
     }
 
     @Test
@@ -195,6 +252,36 @@ class NPlusOneIntegrationTest extends NPlusOneTestSupport {
         assertThat(count)
                 .as("findById 단일 쿼리 기대")
                 .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts/{id}/likes — 좋아요 상태 조회는 최대 2 쿼리")
+    void getPostLikeStatus_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts/" + targetPostId + "/likes");
+
+        assertThat(count)
+                .as("좋아요 여부와 카운트 조회는 고정 쿼리 수여야 함")
+                .isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("GET /posts/type — 게시글 타입별 카운트는 최대 1 쿼리")
+    void getPostTypeCount_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/posts/type?type=COMPLETED");
+
+        assertThat(count)
+                .as("게시글 타입 count 쿼리 단일 실행 기대")
+                .isLessThanOrEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("GET /images/status — 이미지 수 조회는 최대 1 쿼리")
+    void getImageStatus_nPlusOne() throws Exception {
+        int count = callAndGetQueryCount("/images/status");
+
+        assertThat(count)
+                .as("이미지 count 쿼리 단일 실행 기대")
+                .isLessThanOrEqualTo(1);
     }
 
     @Test

--- a/src/test/java/kr/kakaotech/community/integration/NPlusOneTestSupport.java
+++ b/src/test/java/kr/kakaotech/community/integration/NPlusOneTestSupport.java
@@ -1,0 +1,55 @@
+package kr.kakaotech.community.integration;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kr.kakaotech.community.global.monitoring.QueryCountHolder;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * N+1 감지용 통합 테스트 베이스.
+ *
+ * <p>MockMvc는 {@code Filter} 타입 빈을 필터 체인에 자동 편입한다 ({@code FilterRegistrationBean}은 제외).
+ * 따라서 {@link OncePerRequestFilter}를 직접 @Bean으로 노출해야 MockMvc가 체인에 포함한다.
+ *
+ * <p>필터는 {@code @Order(LOWEST_PRECEDENCE)}로 가장 안쪽에 배치해, MDCFilter(HIGHEST)의 finally 블록이
+ * {@link QueryCountHolder}를 리셋하기 직전에 쿼리 카운트를 응답 헤더 {@code X-Query-Count}로 내보낸다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(NPlusOneTestSupport.QueryCountCaptureConfig.class)
+public abstract class NPlusOneTestSupport {
+
+    public static final String QUERY_COUNT_HEADER = "X-Query-Count";
+
+    @TestConfiguration
+    public static class QueryCountCaptureConfig {
+
+        @Bean
+        @Order(Ordered.LOWEST_PRECEDENCE)
+        public OncePerRequestFilter queryCountCaptureFilter() {
+            return new OncePerRequestFilter() {
+                @Override
+                protected void doFilterInternal(HttpServletRequest request,
+                                                HttpServletResponse response,
+                                                FilterChain filterChain)
+                        throws ServletException, IOException {
+                    filterChain.doFilter(request, response);
+                    response.setHeader(QUERY_COUNT_HEADER, String.valueOf(QueryCountHolder.getCount()));
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
@@ -18,7 +18,10 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,16 +37,26 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <pre>
  *   초기 상태: userA가 postX에 좋아요를 누른 상태 (row 1개, like_count=1)
  *   N개 스레드가 동시에 toggleLike(userA, postX) 호출
- *   → 모두 "있음 → 취소" 경로로 진입
- *   → delete는 1번만 실제로 일어나지만 decrement가 N번 실행
- *   → like_count ≠ 실제 row 수 (정합성 깨짐)
  * </pre>
+ *
+ * <p><b>실측 결과 (Before 비관적 락)</b>:
+ * <ul>
+ *   <li>정합성({@code like_count == row 수})은 유지된다. 원인: Hibernate가 managed 엔티티
+ *       {@code delete()} 시 flush 시점에 자동 stale detection을 수행하기 때문.
+ *       한 스레드가 먼저 DELETE를 커밋하면 나머지는 {@code StaleObjectStateException}으로 롤백된다.
+ *       {@code @Modifying} 쿼리({@code decrementLikeCount})가 auto-flush를 트리거하므로
+ *       DELETE가 먼저 실행되고, stale이면 UPDATE는 아예 실행되지 않는다.</li>
+ *   <li><b>가용성이 깨진다</b>: 10개 스레드 중 1개만 성공, 9개는 500 에러.
+ *       사용자 입장에서는 "동시 클릭 시 대부분 실패"하는 심각한 UX 문제.</li>
+ * </ul>
+ *
+ * <p>즉 이 버그는 "정합성 깨짐"이 아니라 <b>"가용성 깨짐"</b>으로 재정의되어야 한다.
+ * 비관적 락을 적용하면 요청이 직렬화되어 모든 요청이 성공하게 된다.
  *
  * <p>주의:
  * <ul>
  *   <li>테스트 클래스에 {@code @Transactional}을 붙이면 모든 스레드가 단일 트랜잭션을 공유하게 되어
  *       동시성이 사라진다. 따라서 사용하지 않고 {@link #tearDown()}에서 수동 cleanup한다.</li>
- *   <li>H2(MODE=MySQL)에서도 check-then-act race는 재현된다.</li>
  * </ul>
  */
 @SpringBootTest
@@ -98,8 +111,8 @@ class LikeConcurrencyTest {
     }
 
     @Test
-    @DisplayName("시나리오 2: 동시 더블 취소 시 like_count와 실제 row 수가 일치해야 한다")
-    void 동시_더블_취소_정합성() throws InterruptedException {
+    @DisplayName("시나리오 2: 동시 더블 취소 시 모든 요청이 성공하고 정합성이 유지되어야 한다")
+    void 동시_더블_취소_가용성과_정합성() throws InterruptedException {
         // given: setUp에서 좋아요 1개가 이미 등록된 상태
         int threadCount = 10;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
@@ -108,6 +121,9 @@ class LikeConcurrencyTest {
 
         AtomicInteger successCount = new AtomicInteger();
         AtomicInteger failCount = new AtomicInteger();
+        // 예외 종류별 카운트 + 첫 예외 메시지 샘플링
+        Map<String, AtomicInteger> exceptionCounts = new ConcurrentHashMap<>();
+        CopyOnWriteArrayList<String> exceptionSamples = new CopyOnWriteArrayList<>();
 
         // when: N개 스레드가 동시에 toggleLike 호출 (모두 취소 경로 진입 예상)
         for (int i = 0; i < threadCount; i++) {
@@ -118,6 +134,16 @@ class LikeConcurrencyTest {
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();
+                    String type = e.getClass().getName();
+                    exceptionCounts
+                            .computeIfAbsent(type, k -> new AtomicInteger())
+                            .incrementAndGet();
+                    if (exceptionSamples.size() < 3) {
+                        Throwable root = e;
+                        while (root.getCause() != null) root = root.getCause();
+                        exceptionSamples.add(type + " -> " + root.getClass().getSimpleName()
+                                + ": " + root.getMessage());
+                    }
                 } finally {
                     doneLatch.countDown();
                 }
@@ -134,9 +160,17 @@ class LikeConcurrencyTest {
 
         System.out.println("[결과] successCount=" + successCount + ", failCount=" + failCount);
         System.out.println("[결과] actualRows=" + actualRows + ", likeCount=" + likeCount);
+        System.out.println("[예외 종류별] " + exceptionCounts);
+        exceptionSamples.forEach(s -> System.out.println("[예외 샘플] " + s));
 
+        // 1) 정합성: like_count와 실제 row 수 일치
         assertThat(likeCount)
                 .as("like_count는 실제 post_likes row 수와 일치해야 한다")
                 .isEqualTo(actualRows);
+
+        // 2) 가용성: 모든 요청이 성공해야 한다 (비관적 락 없이는 실패 — 9개가 StaleObjectStateException)
+        assertThat(successCount.get())
+                .as("동시 toggleLike 요청은 모두 성공해야 한다 (가용성)")
+                .isEqualTo(threadCount);
     }
 }

--- a/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
@@ -76,9 +76,10 @@ class LikeConcurrencyTest {
     void setUp() {
         // setUp 전체를 하나의 트랜잭션으로 묶어야 @MapsId 관계가 managed 상태에서 persist된다.
         // (repository.save()를 연달아 호출하면 각각 별도 트랜잭션이 되어 detached 참조 문제 발생)
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
         TransactionTemplate tx = new TransactionTemplate(txManager);
         tx.executeWithoutResult(s -> {
-            User user = new User("like-test@example.com", "password", "likeTester", "USER");
+            User user = new User("like-test-" + suffix + "@example.com", "password", "lk_" + suffix, "USER");
             userRepository.save(user);
             userId = user.getId();
 
@@ -104,10 +105,17 @@ class LikeConcurrencyTest {
 
     @AfterEach
     void tearDown() {
-        likeRepository.deleteAll();
-        postStatusRepository.deleteAll();
-        postRepository.deleteAll();
-        userRepository.deleteAll();
+        TransactionTemplate tx = new TransactionTemplate(txManager);
+        tx.executeWithoutResult(s -> {
+            likeRepository.findByUser_IdAndPost_Id(userId, postId)
+                    .ifPresent(likeRepository::delete);
+            postStatusRepository.findById(postId)
+                    .ifPresent(postStatusRepository::delete);
+            postRepository.findById(postId)
+                    .ifPresent(postRepository::delete);
+            userRepository.findById(userId)
+                    .ifPresent(userRepository::delete);
+        });
     }
 
     @Test
@@ -151,8 +159,19 @@ class LikeConcurrencyTest {
         }
 
         startLatch.countDown(); // 모든 스레드 동시 출발
-        doneLatch.await(30, TimeUnit.SECONDS);
+        boolean allDone = doneLatch.await(30, TimeUnit.SECONDS);
         executor.shutdown();
+        boolean executorTerminated = executor.awaitTermination(5, TimeUnit.SECONDS);
+        if (!executorTerminated) {
+            executor.shutdownNow();
+        }
+
+        assertThat(allDone)
+                .as("모든 스레드는 제한 시간 안에 완료되어야 한다")
+                .isTrue();
+        assertThat(executorTerminated)
+                .as("테스트 종료 전 스레드 풀은 정상 종료되어야 한다")
+                .isTrue();
 
         // then: like_count와 실제 post_likes row 수가 일치해야 한다
         int actualRows = likeRepository.countByPost_Id(postId);

--- a/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeConcurrencyTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       한 스레드가 먼저 DELETE를 커밋하면 나머지는 {@code StaleObjectStateException}으로 롤백된다.
  *       {@code @Modifying} 쿼리({@code decrementLikeCount})가 auto-flush를 트리거하므로
  *       DELETE가 먼저 실행되고, stale이면 UPDATE는 아예 실행되지 않는다.</li>
- *   <li><b>가용성이 깨진다</b>: 10개 스레드 중 1개만 성공, 9개는 500 에러.
+ *   <li><b>가용성이 깨진다</b>: 100개 스레드 중 1개만 성공, 99개는 500 에러.
  *       사용자 입장에서는 "동시 클릭 시 대부분 실패"하는 심각한 UX 문제.</li>
  * </ul>
  *
@@ -114,7 +114,7 @@ class LikeConcurrencyTest {
     @DisplayName("시나리오 2: 동시 더블 취소 시 모든 요청이 성공하고 정합성이 유지되어야 한다")
     void 동시_더블_취소_가용성과_정합성() throws InterruptedException {
         // given: setUp에서 좋아요 1개가 이미 등록된 상태
-        int threadCount = 10;
+        int threadCount = 100;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch doneLatch = new CountDownLatch(threadCount);
@@ -151,15 +151,19 @@ class LikeConcurrencyTest {
         }
 
         startLatch.countDown(); // 모든 스레드 동시 출발
-        doneLatch.await(10, TimeUnit.SECONDS);
+        doneLatch.await(30, TimeUnit.SECONDS);
         executor.shutdown();
 
         // then: like_count와 실제 post_likes row 수가 일치해야 한다
         int actualRows = likeRepository.countByPost_Id(postId);
         int likeCount = postStatusRepository.findById(postId).orElseThrow().getLikeCount();
 
-        System.out.println("[결과] successCount=" + successCount + ", failCount=" + failCount);
-        System.out.println("[결과] actualRows=" + actualRows + ", likeCount=" + likeCount);
+        System.out.println("[설정] 초기 상태 like_count=1, threadCount=" + threadCount
+                + " (모두 동일 유저/게시글에 동시 toggleLike → 전원 취소 경로 진입)");
+        System.out.println("[결과] successCount=" + successCount + ", failCount=" + failCount
+                + " (가용성 = " + successCount.get() + "/" + threadCount + ")");
+        System.out.println("[결과] actualRows=" + actualRows + ", likeCount=" + likeCount
+                + " (정합성 " + (actualRows == likeCount ? "OK" : "FAIL") + ")");
         System.out.println("[예외 종류별] " + exceptionCounts);
         exceptionSamples.forEach(s -> System.out.println("[예외 샘플] " + s));
 

--- a/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
+++ b/src/test/java/kr/kakaotech/community/service/LikeServiceTest.java
@@ -68,6 +68,7 @@ class LikeServiceTest {
             User userRef = mock(User.class);
             Post postRef = mock(Post.class);
 
+            given(postStatusRepository.findByIdForUpdate(postId)).willReturn(Optional.of(postStatus));
             given(likeRepository.findByUser_IdAndPost_Id(userId, postId)).willReturn(Optional.empty());
             given(userRepository.getReferenceById(userId)).willReturn(userRef);
             given(postRepository.getReferenceById(postId)).willReturn(postRef);
@@ -94,6 +95,7 @@ class LikeServiceTest {
             // given
             PostLike existingLike = mock(PostLike.class);
 
+            given(postStatusRepository.findByIdForUpdate(postId)).willReturn(Optional.of(postStatus));
             given(likeRepository.findByUser_IdAndPost_Id(userId, postId)).willReturn(Optional.of(existingLike));
             // getLikeCount 내부 호출
             ReflectionTestUtils.setField(postStatus, "likeCount", 0);
@@ -118,6 +120,7 @@ class LikeServiceTest {
             User userRef = mock(User.class);
             Post postRef = mock(Post.class);
 
+            given(postStatusRepository.findByIdForUpdate(postId)).willReturn(Optional.of(postStatus));
             given(likeRepository.findByUser_IdAndPost_Id(userId, postId)).willReturn(Optional.empty());
             given(userRepository.getReferenceById(userId)).willReturn(userRef);
             given(postRepository.getReferenceById(postId)).willReturn(postRef);

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,64 @@
+server:
+  servlet:
+    context-path: /api
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/community?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        format_sql: false
+        dialect: org.hibernate.dialect.MySQLDialect
+    show-sql: false
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  docker:
+    compose:
+      enabled: false
+
+image:
+  storage:
+    type: local
+  upload:
+    profile-url: http://test
+    post-url: http://test
+
+auth:
+  type: jwt
+
+jwt:
+  expirationtime:
+    accessTtl: 1800
+    refreshTtl: 604800
+  secret: ${JWT_SECRET:dGVzdC1vbmx5LW5vbi1zZW5zaXRpdmUtc2VjcmV0LWZvci1pbnRlZ3JhdGlvbi10ZXN0}
+
+session:
+  sessionTtl: 1800
+
+upload-dir:
+  image: uploads/images
+
+cors:
+  exposedHeaders:
+    - Authorization
+    - Content-Type
+    - access
+    - refresh
+  allowedOrigins: http://localhost:3000
+
+exclusive-path: /api/auth, /api/error, /api/images, /api/posts/top10, /api/health, /api/uploads, /api/posts/type, /api/images/status, /api/actuator, /actuator
+
+data:
+  generator:
+    enabled: false

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -4,6 +4,8 @@ server:
 
 spring:
   datasource:
+    # Local/CI integration tests use an isolated Docker Compose MySQL instance on the same host.
+    # SSL is intentionally disabled and public key retrieval enabled for this disposable test-only DB.
     url: jdbc:mysql://localhost:3306/community?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
     username: root
     password: root


### PR DESCRIPTION
## 변경 사항

- 주요 조회 API의 요청별 SQL 쿼리 수를 검증하는 N+1 통합 테스트를 추가했습니다.
- 테스트 환경에서 요청별 쿼리 카운트를 응답 헤더로 노출하는 지원 구성을 추가했습니다.
- API 성공/실패 흐름을 MockMvc 통합 테스트로 보강했습니다.
- 좋아요 토글 동시성 테스트와 관련 서비스 테스트를 함께 보강했습니다.

## 의도

조회 API가 데이터 건수 증가에 따라 추가 쿼리를 발생시키는지 테스트 단계에서 감지하고, 주요 API의 인증/권한/예외 흐름 회귀를 함께 막기 위한 변경입니다.

## 검증

- `./gradlew test --tests kr.kakaotech.community.integration.NPlusOneIntegrationTest --tests kr.kakaotech.community.integration.ApiFunctionalIntegrationTest --tests kr.kakaotech.community.service.LikeConcurrencyTest`
- `git push` pre-push 훅에서 `./gradlew clean test jacocoTestCoverageVerification jacocoTestReport` 통과

## 참고

현재 로컬 작업트리에는 k6와 Redis 검증 문서 작업이 미커밋 상태로 남아 있으며, 이 PR에는 포함하지 않았습니다.