### PR TITLE
test: N+1 통합 테스트 기본 검증 제외 및 PR CI 분리

### DIFF
--- a/.github/workflows/ci-cd-ec2.yml
+++ b/.github/workflows/ci-cd-ec2.yml
@@ -11,10 +11,8 @@ on:
       - dev
 
 jobs:
-  build-and-push:
+  test:
     runs-on: ubuntu-latest
-    environment: production
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +29,25 @@ jobs:
 
       - name: Test
         run: ./gradlew clean test --console=plain
+
+  build-and-push:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
 
       - name: Build with Gradle
         run: ./gradlew build -x test --console=plain

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,8 @@ dependencies {
 
 }
 
-test {
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
     testLogging {
         events "passed", "skipped", "failed"
         showStandardStreams = true
@@ -82,8 +83,21 @@ test {
 }
 
 tasks.named('test') {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'nplusone'
+    }
     finalizedBy tasks.named('jacocoTestReport')
+}
+
+tasks.register('nPlusOneTest', Test) {
+    description = 'Runs N+1 integration tests that require local MySQL/Redis.'
+    group = 'verification'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    shouldRunAfter tasks.named('test')
+    useJUnitPlatform {
+        includeTags 'nplusone'
+    }
 }
 
 jacoco {

--- a/src/test/java/kr/kakaotech/community/integration/ApiFunctionalIntegrationTest.java
+++ b/src/test/java/kr/kakaotech/community/integration/ApiFunctionalIntegrationTest.java
@@ -45,7 +45,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "jwt.expirationtime.accessTtl=1800",
+        "jwt.expirationtime.refreshTtl=604800",
+        "jwt.secret=test-only-no-sensitive-secret-for-integration-test"
+})
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional

--- a/src/test/java/kr/kakaotech/community/integration/NPlusOneTestSupport.java
+++ b/src/test/java/kr/kakaotech/community/integration/NPlusOneTestSupport.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import kr.kakaotech.community.global.monitoring.QueryCountHolder;
+import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -28,7 +29,8 @@ import java.io.IOException;
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("nplusone")
+@Tag("nplusone")
 @Import(NPlusOneTestSupport.QueryCountCaptureConfig.class)
 public abstract class NPlusOneTestSupport {
 

--- a/src/test/resources/application-nplusone.yaml
+++ b/src/test/resources/application-nplusone.yaml
@@ -4,7 +4,7 @@ server:
 
 spring:
   datasource:
-    # Local/CI integration tests use an isolated Docker Compose MySQL instance on the same host.
+    # N+1 integration tests use an isolated Docker Compose MySQL instance on the same host.
     # SSL is intentionally disabled and public key retrieval enabled for this disposable test-only DB.
     url: jdbc:mysql://localhost:3306/community?serverTimezone=UTC&useSSL=false&allowPublicKeyRetrieval=true
     username: root


### PR DESCRIPTION
## 요약
- N+1 통합 테스트를 `nplusone` 태그와 전용 Gradle 태스크로 분리했습니다.
- 기본 `test` 태스크에서는 `nplusone` 태그를 제외해 CI/CD 기본 테스트가 외부 MySQL/Redis 의존성 때문에 실패하지 않도록 했습니다.
- PR 이벤트에서도 `./gradlew clean test`가 실행되도록 CI/CD 워크플로우를 `test` job과 배포 job으로 분리했습니다.

## 배경
PR #91에서는 테스트 job이 `push` 조건 때문에 스킵되어, 실패가 머지 이후 `dev` 배포 단계에서야 발견됐습니다. 이제 PR 단계에서 기본 테스트 실패를 먼저 확인할 수 있습니다.

## 검증
- `./gradlew test --console=plain`
- pre-push hook `clean test` 통과
- `./gradlew nPlusOneTest --dry-run --console=plain`