### PR TITLE
ci: 수동 브랜치 배포 워크플로 추가

### DIFF
--- a/.github/workflows/deploy-branch-ec2.yml
+++ b/.github/workflows/deploy-branch-ec2.yml
@@ -1,0 +1,121 @@
+name: Deploy Branch to EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: '배포할 브랜치명'
+        required: true
+        default: 'dev'
+      run_tests:
+        description: '배포 전 테스트 실행'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-branch-ec2
+  cancel-in-progress: false
+
+jobs:
+  deploy-branch:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      BACKEND_APP_DIR: /opt/community/V1/docker/app
+
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Test
+        if: ${{ inputs.run_tests }}
+        run: ./gradlew clean test --console=plain
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test --console=plain
+
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Resolve image metadata
+        id: meta
+        run: |
+          SAFE_BRANCH="$(printf '%s' "${{ inputs.branch }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//' \
+            | cut -c1-80)"
+          SHORT_SHA="$(git rev-parse --short=12 HEAD)"
+          IMAGE_TAG="manual-${SAFE_BRANCH}-${SHORT_SHA}-${GITHUB_RUN_NUMBER}"
+
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_uri=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${{ secrets.ECR_REPOSITORY }}:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: ${{ steps.meta.outputs.image_uri }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Send SSM Command
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          BACK_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.meta.outputs.image_tag }}
+          TARGET_BRANCH: ${{ inputs.branch }}
+          TARGET_SHA: ${{ steps.meta.outputs.short_sha }}
+        run: |
+          DEPLOY_COMMAND="AWS_REGION=${AWS_REGION} AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID} BACK_REPOSITORY=${BACK_REPOSITORY} bash deploy.sh backend ${IMAGE_TAG}"
+
+          aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --document-name "AWS-RunShellScript" \
+            --targets "Key=tag:Environment,Values=prod" "Key=tag:DeployTarget,Values=community-app" \
+            --comment "Deploy Backend branch ${TARGET_BRANCH} (${TARGET_SHA})" \
+            --parameters "commands=[\"cd ${BACKEND_APP_DIR}\",\"${DEPLOY_COMMAND}\"]" \
+            --output text
+
+      - name: Deployment summary
+        run: |
+          {
+            echo "### Branch deployment"
+            echo "- Branch: \`${{ inputs.branch }}\`"
+            echo "- Commit: \`${{ steps.meta.outputs.short_sha }}\`"
+            echo "- Image tag: \`${{ steps.meta.outputs.image_tag }}\`"
+            echo "- Tests: \`${{ inputs.run_tests }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 변경 사항

- 수동 실행 가능한 브랜치 배포 workflow를 추가했습니다.
- 입력한 브랜치를 checkout해 기존 dev 배포와 같은 Gradle build, ECR push, SSM deploy 흐름을 사용합니다.
- 배포 이미지는 `latest` 대신 `manual-{branch}-{sha}-{run_number}` 태그로 push하고 해당 태그를 EC2 deploy.sh에 전달합니다.
- `run_tests` 입력으로 배포 전 테스트 실행 여부를 선택할 수 있습니다.

## 환경 변수/시크릿

기존 dev 배포에서 쓰는 GitHub Secrets를 그대로 사용합니다. 별도 추가 입력값이나 새 Secret은 필요 없습니다.

## 검증

- `git diff --check`
- YAML 파싱 확인

## 참고

이 workflow 파일이 dev에 merge된 뒤 GitHub Actions의 수동 실행 화면에서 `performance/top10-db-index` 같은 브랜치를 지정해 배포할 수 있습니다.